### PR TITLE
Init params: Hyperswitch should not explode if logger or metrics is undefined

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -378,7 +378,11 @@ HyperSwitch.prototype._request = function(req, options) {
             reqHandlerPromise = P.try(handler, [childHyperSwitch, childReq]);
         }
 
-        reqHandlerPromise = childHyperSwitch._wrapInMetrics(reqHandlerPromise, match, req)
+        if (self.metrics) {
+            reqHandlerPromise = childHyperSwitch._wrapInMetrics(reqHandlerPromise, match, req);
+        }
+
+        reqHandlerPromise = reqHandlerPromise
         .then(function(res) {
             childHyperSwitch.log('trace/hyper/response', {
                 req: req,

--- a/lib/server.js
+++ b/lib/server.js
@@ -214,10 +214,12 @@ function handleResponse(opts, req, resp, response) {
             delete response.body;
         }
 
-        opts.metrics.endTiming([
+        if (opts.metrics) {
+            opts.metrics.endTiming([
                 'ALL.ALL',
                 req.method.toUpperCase() + '.' + response.status.toString()
-        ], opts.startTime);
+            ], opts.startTime);
+        }
 
         if (response.body) {
             body = response.body;
@@ -288,7 +290,7 @@ function handleRequest(opts, req, resp) {
 
     var reqOpts = {
         conf: opts.conf,
-        logger: opts.logger.child({
+        logger: opts.logger && opts.logger.child({
             root_req: {
                 method: req.method.toLowerCase(),
                 uri: req.url,
@@ -309,7 +311,7 @@ function handleRequest(opts, req, resp) {
         metrics: opts.metrics,
         startTime: Date.now()
     };
-    reqOpts.log = reqOpts.logger.log.bind(reqOpts.logger);
+    reqOpts.log = reqOpts.logger && reqOpts.logger.log.bind(reqOpts.logger) || function() {};
 
     /**
      * We use separate metric trees for requests from private networks, so
@@ -397,27 +399,18 @@ function handleRequest(opts, req, resp) {
     });
 }
 
-function setupConfigDefaults(conf) {
-    if (!conf) { conf = {}; }
-    if (!conf.logging) { conf.logging = {}; }
-    if (!conf.logging.name) { conf.logging.name = 'hyperswitch'; }
-    if (!conf.logging.level) { conf.logging.level = 'warn'; }
-    return conf;
-}
-
 // Main app setup
 function main(options) {
-    var conf = setupConfigDefaults(options.config);
     // Set up the global options object with a logger
     var opts = {
         appBasePath: options.appBasePath,
-        conf: conf,
+        conf: options.config,
         logger: options.logger,
-        log: options.logger.log.bind(options.logger),
+        log: options.logger && options.logger.log.bind(options.logger) || function() {},
         metrics: options.metrics,
         child_metrics: {
-            internal: options.metrics.makeChild('private'),
-            internal_update: options.metrics.makeChild('internal_update'),
+            internal: options.metrics && options.metrics.makeChild('private'),
+            internal_update: options.metrics && options.metrics.makeChild('internal_update')
         }
     };
 
@@ -427,14 +420,14 @@ function main(options) {
     // direct requests to /sys
     var childHyperSwitch = opts.hyper.makeChild({ uri: '#internal-startup' });
     // Main app startup happens during async spec loading:
-    return opts.router.loadSpec(conf.spec, childHyperSwitch)
-    .then(function(router) {
+    return opts.router.loadSpec(options.config.spec, childHyperSwitch)
+    .then(function() {
         var server = http.createServer(handleRequest.bind(null, opts));
         // Use a large listen queue
         // Also, echo 1024 | sudo tee /proc/sys/net/core/somaxconn
         // (from 128 default)
-        var port = conf.port || 7231;
-        var host = conf.host;
+        var port = options.config.port || 7231;
+        var host = options.config.host;
         // Apply some back-pressure.
         server.maxConnections = 500;
         server.listen(port, host);

--- a/lib/server.js
+++ b/lib/server.js
@@ -401,10 +401,11 @@ function handleRequest(opts, req, resp) {
 
 // Main app setup
 function main(options) {
+    var conf = options.config || {};
     // Set up the global options object with a logger
     var opts = {
         appBasePath: options.appBasePath,
-        conf: options.config,
+        conf: conf,
         logger: options.logger,
         log: options.logger && options.logger.log.bind(options.logger) || function() {},
         metrics: options.metrics,
@@ -420,14 +421,14 @@ function main(options) {
     // direct requests to /sys
     var childHyperSwitch = opts.hyper.makeChild({ uri: '#internal-startup' });
     // Main app startup happens during async spec loading:
-    return opts.router.loadSpec(options.config.spec, childHyperSwitch)
+    return opts.router.loadSpec(conf.spec, childHyperSwitch)
     .then(function() {
         var server = http.createServer(handleRequest.bind(null, opts));
         // Use a large listen queue
         // Also, echo 1024 | sudo tee /proc/sys/net/core/somaxconn
         // (from 128 default)
-        var port = options.config.port || 7231;
-        var host = options.config.host;
+        var port = conf.port || 7231;
+        var host = conf.host;
         // Apply some back-pressure.
         server.maxConnections = 500;
         server.listen(port, host);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ajv": "^3.4.0"
   },
   "devDependencies": {
-    "bunyan": "^1.5.1",
     "coveralls": "^2.11.6",
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4",

--- a/test/hyperswitch/test_config.yaml
+++ b/test/hyperswitch/test_config.yaml
@@ -57,6 +57,18 @@ spec_root: &spec_root
                 body: 'abcdef'
         x-monitor: false
 
+    /service/json_body:
+      post:
+        x-request-handler:
+          - get_from_api:
+              return:
+                status: 200
+                headers:
+                  content-type: 'application/json'
+                body:
+                  result: '{$.request.body.field}'
+        x-monitor: false
+
     /service/hop_to_hop:
       get:
         x-request-handler:


### PR DESCRIPTION
Providing logger and metrics to hyper switch initialiser would be optional, so it shouldn't crash if they're undefined.