### PR TITLE
Fix module loading and release v0.1.2

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -6,6 +6,7 @@ var fs = P.promisifyAll(require('fs'));
 var handlerTemplate = require('./handlerTemplate');
 var swaggerRouter = require('swagger-router');
 var Validator = require('./validator');
+var path = require('path');
 
 var Node = swaggerRouter.Node;
 var Template = swaggerRouter.Template;
@@ -74,6 +75,35 @@ Router.prototype._buildPath = function route(node, path, value) {
     return node;
 };
 
+/**
+ * Tries to require the module supplied in the configuration
+ */
+Router.prototype._requireModule = function(modName) {
+    var self = this;
+    var opts = arguments[1] || { mod: modName, baseTried: false, modsTried: false };
+    try {
+        return require(modName);
+    } catch (e) {
+        if (/^\//.test(opts.mod) || (opts.baseTried && opts.modsTried)) {
+            // we have a full path here which can't be required, or we tried
+            // all of the possible combinations, so bail out
+            e.moduleName = opts.mod;
+            throw e;
+        } else {
+            // This might be a relative path, convert it to absolute and try again
+            if (!opts.baseTried) {
+                // first, try to load it from the app's base path
+                opts.baseTried = true;
+                modName = path.join(self._options.appBasePath, opts.mod);
+            } else {
+                // then, retry its node_modules directory
+                opts.modsTried = true;
+                modName = path.join(self._options.appBasePath, 'node_modules', opts.mod);
+            }
+            return self._requireModule(modName, opts);
+        }
+    }
+};
 
 /**
  * Load and initialize a module
@@ -157,10 +187,7 @@ Router.prototype._loadModule = function(modDef, globals) {
         });
     } else {
         // Let the error propagate in case the module cannot be loaded
-        var modObj = require(loadPath);
-        if (!modObj) {
-            return P.reject("Loading module " + loadPath + " failed.");
-        }
+        var modObj = self._requireModule(loadPath);
         // Call if it's a function
         if (modObj instanceof Function) {
             modObj = modObj(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
One can specify an npm module name to load in the configuration and/or
specification file. Node then tries to find it in the usual way - by
searching the path up to root for that module and in the global modules'
directory. However, node starts the search from hyperswitch' path,
not the application's. Unfortunately, this doesn't work in cases where
node modules are symlinked into the relevant node_modules directory. So,
when a relative path is encountered and the module fails to load, try to
load it both from the application's base path as well as its
node_modules sub-directory, if one exists.