### PR TITLE
Removed encode/decodeToken functions from HyperSweitch

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -66,11 +66,6 @@ function HyperSwitch(options, req, parOptions) {
 
         options.maxDepth = options.maxDepth || 10;
 
-        if (!options.conf.salt || typeof options.conf.salt !== 'string') {
-            throw new Error("Missing or invalid `salt` option in HyperSwitch config. "
-                    + "Expected a string.");
-        }
-
         // Private state, shared with child instances
         this._priv = {
             options: options,

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -4,7 +4,6 @@
  * HyperSwitch request dispatcher and general shared per-request state namespace
  */
 
-var jwt = require('jsonwebtoken');
 var P = require('bluebird');
 var utils = require('./utils');
 var HTTPError = require('./exports').HTTPError;
@@ -456,33 +455,5 @@ methods.forEach(function(method) {
         return this._request(makeRequest(uri, req, method));
     };
 });
-
-
-// Utility methods that need access to HyperSwitch state.
-
-// Create a json web token
-// @param {string} token
-// @return {string} JWT signed token
-HyperSwitch.prototype.encodeToken = function(token) {
-    return jwt.sign({ next: token }, this._priv.options.conf.salt);
-};
-
-// Decode signed token and decode the orignal token
-// @param {string} JWT token
-// @return {string} original token
-HyperSwitch.prototype.decodeToken = function(token) {
-    try {
-        var next = jwt.verify(token, this._priv.options.conf.salt);
-        return next.next;
-    } catch (e) {
-        throw new HTTPError({
-            status: 400,
-            body: {
-                type: 'invalid_paging_token',
-                title: 'Invalid paging token'
-            }
-        });
-    }
-};
 
 module.exports = HyperSwitch;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "bluebird": "^3.1.1",
     "busboy": "^0.2.12",
     "js-yaml": "^3.5.2",
-    "jsonwebtoken": "^5.5.4",
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.8",
     "swagger-router": "^0.3.4",

--- a/test/handlerTemplate/test_config.yaml
+++ b/test/handlerTemplate/test_config.yaml
@@ -120,7 +120,6 @@ services:
     conf:
       port: 12345
       spec: *spec_root
-      salt: secret
       default_page_size: 1
       user_agent: HyperSwitch-testsuite
 

--- a/test/hyperswitch/test_config.yaml
+++ b/test/hyperswitch/test_config.yaml
@@ -68,7 +68,6 @@ services:
     conf:
       port: 12345
       spec: *spec_root
-      salt: secret
       default_page_size: 1
       user_agent: HyperSwitch-testsuite
 

--- a/test/streaming/test_config.yaml
+++ b/test/streaming/test_config.yaml
@@ -15,7 +15,6 @@ services:
     conf:
       port: 12345
       spec: *spec_root
-      salt: secret
       default_page_size: 1
       user_agent: HyperSwitch-testsuite
 


### PR DESCRIPTION
These 2 functions don't belong neither in HyperSwitch object nor in the framework. 

Changes shouldn't be released until https://github.com/wikimedia/restbase/pull/509 is merged