### PR TITLE
Metrics: private -> internal & <default> -> external

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -327,6 +327,8 @@ function handleRequest(opts, req, resp) {
         } else {
             reqOpts.metrics = opts.child_metrics.internal;
         }
+    } else {
+        reqOpts.metrics = opts.child_metrics.external;
     }
 
     // Create a new, clean request object
@@ -410,8 +412,9 @@ function main(options) {
         log: options.logger && options.logger.log.bind(options.logger) || function() {},
         metrics: options.metrics,
         child_metrics: {
-            internal: options.metrics && options.metrics.makeChild('private'),
-            internal_update: options.metrics && options.metrics.makeChild('internal_update')
+            external: options.metrics && options.metrics.makeChild('external'),
+            internal: options.metrics && options.metrics.makeChild('internal'),
+            internal_update: options.metrics && options.metrics.makeChild('internal_update'),
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Rename 'private' metrics to 'internal'.
- Prefix external metrics with 'external', rather than the empty default. This
  makes this symmetric with internal / internal-update requests, which in turn
  simplifies wildcard selections in dashboards.

Note: Deploying this involves several metric renames, and should be
coordinated with ops to avoid losing metrics.