### PR TITLE
v0.1.3 Strip out hop-to-hop headers when proxying responses

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -122,13 +122,21 @@ function logResponse(opts, response) {
  * @private
  */
 function removeHopToHopHeaders(rh) {
-    // Need to delete properties and not set to undefined
-    // because node passes 'undefined' to client.
-    delete rh.connection;
-    delete rh['keep-alive'];
-    delete rh.public;
-    delete rh['proxy-authenticate'];
-    delete rh['transfer-encoding'];
+    [
+        'connection',
+        'keep-alive',
+        'public',
+        'proxy-authenticate',
+        'transfer-encoding',
+        'content-length',
+        'content-encoding'
+    ].forEach(function(headerName) {
+        // Need to delete properties and not set to undefined
+        // because node passes 'undefined' to client.
+        if (rh[headerName]) {
+            delete rh[headerName];
+        }
+    });
 }
 
 
@@ -203,7 +211,6 @@ function handleResponse(opts, req, resp, response) {
         }
 
         if (req.method === 'head') {
-            delete rh['content-length'];
             delete response.body;
         }
 
@@ -213,10 +220,6 @@ function handleResponse(opts, req, resp, response) {
         ], opts.startTime);
 
         if (response.body) {
-
-            delete rh['content-length'];
-            delete rh['content-encoding'];
-
             body = response.body;
             var bodyIsStream = body instanceof stream.Readable;
             if (!Buffer.isBuffer(body) && !bodyIsStream) {
@@ -250,13 +253,6 @@ function handleResponse(opts, req, resp, response) {
                 resp.end(body);
             }
         } else {
-            if (rh['content-length']) {
-                opts.log('warn/response/content-length', {
-                    res: response,
-                    reason: new Error('Invalid content-length')
-                });
-                delete rh['content-length'];
-            }
             resp.writeHead(response.status, '', rh);
             resp.end();
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -100,24 +100,61 @@ function parsePOST(req) {
     }
 }
 
+function logResponse(opts, response) {
+    var logLevel = 'trace/request';
+    if (response.status >= 500) {
+        logLevel = 'error/request';
+    } else if (response.status >= 400) {
+        logLevel = 'info/request';
+    }
+    opts.log(logLevel, {
+        message: response.message,
+        res: response,
+        stack: response.stack
+    });
+}
+
+/**
+ * Removes Hop-To-Hop headers that might be
+ * proxied from a backend service
+ *
+ * @param {Object} rh response headers
+ * @private
+ */
+function removeHopToHopHeaders(rh) {
+    // Need to delete properties and not set to undefined
+    // because node passes 'undefined' to client.
+    delete rh.connection;
+    delete rh['keep-alive'];
+    delete rh.public;
+    delete rh['proxy-authenticate'];
+    delete rh['transfer-encoding'];
+}
+
+
+/**
+ * Set up basic CORS in response headers
+ *
+ * @param {Object} rh Response headers object
+ * @private
+ */
+function setCORSHeaders(rh) {
+    rh['access-control-allow-origin'] = '*';
+    rh['access-control-allow-methods'] = 'GET';
+    rh['access-control-allow-headers'] = 'accept, content-type';
+    rh['access-control-expose-headers'] = 'etag';
+}
+
 function handleResponse(opts, req, resp, response) {
     if (response && response.status) {
-        if (!response.headers) {
-            response.headers = {};
-        }
+        var rh = response.headers = response.headers || {};
 
-        var rh = response.headers;
+        removeHopToHopHeaders(rh);
+        setCORSHeaders(rh);
 
         // Default to no server-side caching
-        if (!rh['cache-control']) {
-            rh['cache-control'] = 'private, max-age=0, s-maxage=0, must-revalidate';
-        }
-
-        // Set up CORS
-        rh['access-control-allow-origin'] = '*';
-        rh['access-control-allow-methods'] = 'GET';
-        rh['access-control-allow-headers'] = 'accept, content-type';
-        rh['access-control-expose-headers'] = 'etag';
+        rh['cache-control'] = rh['cache-control']
+            || 'private, max-age=0, s-maxage=0, must-revalidate';
 
         // Set up security headers
         // https://www.owasp.org/index.php/List_of_useful_HTTP_headers
@@ -129,17 +166,7 @@ function handleResponse(opts, req, resp, response) {
         // Propagate the request id header
         rh['x-request-id'] = opts.reqId;
 
-        var logLevel = 'trace/request';
-        if (response.status >= 500) {
-            logLevel = 'error/request';
-        } else if (response.status >= 400) {
-            logLevel = 'info/request';
-        }
-        opts.log(logLevel, {
-            message: response.message,
-            res: response,
-            stack: response.stack
-        });
+        logResponse(opts, response);
 
         var body;
         // Prepare error responses for the client
@@ -157,23 +184,17 @@ function handleResponse(opts, req, resp, response) {
                 uri: rBody.uri
             };
 
-            if (!response.headers['content-type']) {
-                response.headers['content-type'] = 'application/problem+json';
-            }
+            rh['content-type'] = rh['content-type']
+                || 'application/problem+json';
 
             if (response.status === 404) {
-                if (!body.type) { body.type = 'not_found'; }
-                if (!body.title) { body.title = 'Not found.'; }
+                body.type = body.type || 'not_found';
+                body.title = body.title || 'Not found.';
             }
 
-            if (response.status >= 400) {
-                if (!body.uri) { body.uri = req.uri; }
-                if (!body.method) { body.method = req.method; }
-            }
-
-            if (!body.type) {
-                body.type = 'unknown_error';
-            }
+            body.uri = body.uri || req.uri;
+            body.method = body.method || req.method;
+            body.type = body.type || 'unknown_error';
 
             // Prefix error base URL
             // TODO: make the prefix configurable
@@ -182,7 +203,7 @@ function handleResponse(opts, req, resp, response) {
         }
 
         if (req.method === 'head') {
-            delete response.headers['content-length'];
+            delete rh['content-length'];
             delete response.body;
         }
 
@@ -192,27 +213,27 @@ function handleResponse(opts, req, resp, response) {
         ], opts.startTime);
 
         if (response.body) {
+
+            delete rh['content-length'];
+            delete rh['content-encoding'];
+
             body = response.body;
             var bodyIsStream = body instanceof stream.Readable;
             if (!Buffer.isBuffer(body) && !bodyIsStream) {
                 // Convert to a buffer
                 if (typeof body === 'object') {
-                    if (!response.headers['content-type']) {
-                        response.headers['content-type'] = 'application/json';
-                    }
+                    rh['content-type'] = rh['content-type'] || 'application/json';
                     body = new Buffer(JSON.stringify(body));
                 } else {
                     body = new Buffer(body);
                 }
             }
-            var cType = response.headers['content-type'];
+
+            var cType = rh['content-type'];
             if (/\bgzip\b/.test(req.headers['accept-encoding'])
                     && /^application\/json\b|^text\//.test(cType)) {
-                if (response.headers['content-length']) {
-                    delete response.headers['content-length'];
-                }
-                response.headers['content-encoding'] = 'gzip';
-                resp.writeHead(response.status, '', response.headers);
+                rh['content-encoding'] = 'gzip';
+                resp.writeHead(response.status, '', rh);
                 var zStream = zlib.createGzip({ level: 3 });
                 zStream.pipe(resp);
                 if (bodyIsStream) {
@@ -221,22 +242,22 @@ function handleResponse(opts, req, resp, response) {
                     zStream.end(body);
                 }
             } else if (bodyIsStream) {
-                resp.writeHead(response.status, '', response.headers);
+                resp.writeHead(response.status, '', rh);
                 body.pipe(resp);
             } else {
-                response.headers['content-length'] = body.length;
-                resp.writeHead(response.status, '', response.headers);
+                rh['content-length'] = body.length;
+                resp.writeHead(response.status, '', rh);
                 resp.end(body);
             }
         } else {
-            if (response.headers['content-length']) {
+            if (rh['content-length']) {
                 opts.log('warn/response/content-length', {
                     res: response,
                     reason: new Error('Invalid content-length')
                 });
-                delete response.headers['content-length'];
+                rh['content-length'] = undefined;
             }
-            resp.writeHead(response.status, '', response.headers);
+            resp.writeHead(response.status, '', rh);
             resp.end();
         }
     } else {
@@ -245,10 +266,10 @@ function handleResponse(opts, req, resp, response) {
             msg: "No content returned"
         });
 
-        if (!response) { response = {}; }
-        if (!response.headers) { response.headers = {}; }
-
+        response = response || {};
+        response.headers = response.headers || {};
         response.headers['content-type'] = 'application/problem+json';
+
         resp.writeHead(response.status || 500, '', response.headers);
         resp.end(req.method === 'head' ? undefined : JSON.stringify({
             type: 'https://restbase.org/errors/no_content',

--- a/lib/server.js
+++ b/lib/server.js
@@ -255,7 +255,7 @@ function handleResponse(opts, req, resp, response) {
                     res: response,
                     reason: new Error('Invalid content-length')
                 });
-                rh['content-length'] = undefined;
+                delete rh['content-length'];
             }
             resp.writeHead(response.status, '', rh);
             resp.end();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/hyperswitch/hyperswitch.js
+++ b/test/hyperswitch/hyperswitch.js
@@ -103,5 +103,17 @@ describe('HyperSwitch context', function() {
         });
     });
 
+    it('Should strip out hop-to-hop headers', function() {
+        return preq.get({
+            uri: server.hostPort + '/service/hop_to_hop'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers.hasOwnProperty('transfer-encoding'), false);
+            assert.deepEqual(res.headers.hasOwnProperty('public'), false);
+            assert.deepEqual(res.headers.hasOwnProperty('content-encoding'), false);
+        });
+    });
+
     after(function() { return server.stop(); });
 });

--- a/test/hyperswitch/test_config.yaml
+++ b/test/hyperswitch/test_config.yaml
@@ -57,6 +57,18 @@ spec_root: &spec_root
                 body: 'abcdef'
         x-monitor: false
 
+    /service/hop_to_hop:
+      get:
+        x-request-handler:
+          - return_result:
+              return:
+                status: 200
+                headers:
+                  transfer-encoding: chunked
+                  public: GET
+                  content-encoding: gzip
+                body: 'test'
+
 
 # Finally, a standard service-runner config.
 info:


### PR DESCRIPTION
Some of the headers are hop-to-hop, so we don't need to pass them through to the client when proxying a request. Others like `content-length` and `content-encoding` could be changed by `HyperSwitch`, so we should erase them and set up correct variants.

cc @wikimedia/services 