### PR TITLE
Request filters: First implementation draft

### DIFF
--- a/lib/filters/metrics.js
+++ b/lib/filters/metrics.js
@@ -1,0 +1,38 @@
+"use strict";
+
+module.exports = function(hyper, req, next, options, specInfo) {
+    if (!hyper.metrics) {
+        return next(hyper, req);
+    }
+
+    // Remove the /{domain}/ prefix, as it's not very useful in stats
+    var statName = specInfo.path.replace(/\/[^\/]+\//, '') + '.'
+                    + req.method.toUpperCase() + '.';
+    // Normalize invalid chars
+    statName = hyper.metrics.normalizeName(statName);
+    // Start timer
+    var startTime = Date.now();
+
+    return next(hyper, req).then(function(res) {
+        // Record request metrics & log
+        var statusClass = Math.floor(res.status / 100) + 'xx';
+        hyper.metrics.endTiming([
+            statName + res.status,
+            statName + statusClass,
+            statName + 'ALL'
+        ], startTime);
+        return res;
+    },
+    function(err) {
+        var statusClass = '5xx';
+        if (err && err.status) {
+            statusClass = Math.floor(err.status / 100) + 'xx';
+        }
+        hyper.metrics.endTiming([
+            statName + err.status,
+            statName + statusClass,
+            statName + 'ALL',
+        ], startTime);
+        throw err;
+    });
+};

--- a/lib/filters/validator.js
+++ b/lib/filters/validator.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var HTTPError = require('./exports').HTTPError;
+var HTTPError = require('./../exports').HTTPError;
 var constructAjv = require('ajv');
 
 /**
@@ -205,4 +205,21 @@ Validator.prototype.validate = function(req) {
     return req;
 };
 
-module.exports = Validator;
+var CACHE = {};
+
+module.exports = function(hyper, req, next, options, specInfo) {
+    if (specInfo && specInfo.spec && specInfo.spec.parameters) {
+        var key = specInfo.id;
+        var cachedValidator = CACHE[key];
+        if (key && cachedValidator) {
+            cachedValidator.validate(req);
+        } else {
+            var validator = new Validator(specInfo.spec.parameters);
+            if (key) {
+                CACHE[key] = validator;
+            }
+            validator.validate(req);
+        }
+    }
+    return next(hyper, req);
+};

--- a/lib/filters/validator.js
+++ b/lib/filters/validator.js
@@ -205,19 +205,16 @@ Validator.prototype.validate = function(req) {
     return req;
 };
 
-var CACHE = {};
+var CACHE = new Map();
 
 module.exports = function(hyper, req, next, options, specInfo) {
     if (specInfo && specInfo.spec && specInfo.spec.parameters) {
-        var key = specInfo.id;
-        var cachedValidator = CACHE[key];
-        if (key && cachedValidator) {
+        var cachedValidator = CACHE.get(specInfo.spec);
+        if (cachedValidator) {
             cachedValidator.validate(req);
         } else {
             var validator = new Validator(specInfo.spec.parameters);
-            if (key) {
-                CACHE[key] = validator;
-            }
+            CACHE.set(specInfo.spec, validator);
             validator.validate(req);
         }
     }

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -331,32 +331,27 @@ HyperSwitch.prototype._request = function(req, options) {
         // Prepare to call the handler with a child HyperSwitch instance
         var childHyperSwitch = this.makeChild(childReq, options);
 
-        var reqHandler = P.method(handler);
-        if (match.filters) {
-            var specInfo = {
-                path: match.value.path,
-                spec: handler.spec
-            };
+        var specInfo = {
+            path: match.value.path,
+            spec: handler.spec
+        };
+        var filterIdx = 0;
+        var reqHandler = function handlerWrapper(req, hyper) {
+            if (filterIdx < match.filters.length) {
+                var filter = match.filters[filterIdx];
+                filterIdx++;
 
-            for (var idx = match.filters.length - 1; idx >= 0; idx--) {
-                var filter = match.filters[idx];
                 if (filter.method
-                        && filter.method !== req.method
-                        && !(filter.method === 'get' && req.method === 'head')) {
-                    continue;
+                    && filter.method !== req.method
+                    && !(filter.method === 'get' && req.method === 'head')) {
+                    return handlerWrapper(req, hyper);
                 }
 
-                reqHandler = (function(currentHandler, currentFilter) {
-                    return function(hyper, req) {
-                        return currentFilter.filter(hyper,
-                            req,
-                            currentHandler,
-                            currentFilter.options,
-                            specInfo);
-                    };
-                })(reqHandler, filter);
+                return filter.filter(req, hyper, handlerWrapper, filter.options, specInfo);
+            } else {
+                return P.method(handler)(req, hyper);
             }
-        }
+        };
 
         // This is a hack. Pure P.try get's executed on this tick, but we wanna
         // wrap it in metrics and access checks and start execution only afterwards.

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -255,40 +255,6 @@ HyperSwitch.prototype.request = function(req, options) {
     return this._request(req, options);
 };
 
-HyperSwitch.prototype._wrapInMetrics = function(handlerPromise, match, req) {
-    var self = this;
-    // Remove the /{domain}/ prefix, as it's not very useful in stats
-    var statName = match.value.path.replace(/\/[^\/]+\//, '')
-            + '.' + req.method.toUpperCase() + '.';
-    // Normalize invalid chars
-    statName = self.metrics.normalizeName(statName);
-    // Start timer
-    var startTime = Date.now();
-
-    return handlerPromise.then(function(res) {
-        // Record request metrics & log
-        var statusClass = Math.floor(res.status / 100) + 'xx';
-        self.metrics.endTiming([
-                statName + res.status,
-                statName + statusClass,
-                statName + 'ALL',
-        ], startTime);
-        return res;
-    },
-    function(err) {
-        var statusClass = '5xx';
-        if (err && err.status) {
-            statusClass = Math.floor(err.status / 100) + 'xx';
-        }
-        self.metrics.endTiming([
-                statName + err.status,
-                statName + statusClass,
-                statName + 'ALL',
-        ], startTime);
-        throw err;
-    });
-};
-
 HyperSwitch.prototype._wrapInAccessCheck = function(handlerPromise, match, childReq) {
     var self = this;
     // Don't need to check access restrictions on /sys requests,
@@ -365,22 +331,41 @@ HyperSwitch.prototype._request = function(req, options) {
         // Prepare to call the handler with a child HyperSwitch instance
         var childHyperSwitch = this.makeChild(childReq, options);
 
-        // Call the handler with P.try to catch synchronous exceptions.
-        var reqHandlerPromise;
-        if (handler.validator) {
-            reqHandlerPromise = P.try(function() {
-                return handler.validator.validate(childReq);
-            })
-            .then(function() {
-                return handler(childHyperSwitch, childReq);
-            });
-        } else {
-            reqHandlerPromise = P.try(handler, [childHyperSwitch, childReq]);
+        var reqHandler = P.method(handler);
+        if (match.filters) {
+            var specInfo = {
+                path: match.value.path,
+                spec: handler.spec,
+                id: handler.id
+            };
+
+            for (var idx = match.filters.length - 1; idx >= 0; idx--) {
+                var filter = match.filters[idx];
+                if (filter.method
+                        && filter.method !== req.method
+                        && !(filter.method === 'get' && req.method === 'head')) {
+                    continue;
+                }
+
+                reqHandler = (function(currentHandler, currentFilter) {
+                    return function(hyper, req) {
+                        return currentFilter.filter(hyper,
+                            req,
+                            currentHandler,
+                            currentFilter.options,
+                            specInfo);
+                    };
+                })(reqHandler, filter);
+            }
         }
 
-        if (self.metrics) {
-            reqHandlerPromise = childHyperSwitch._wrapInMetrics(reqHandlerPromise, match, req);
-        }
+        // This is a hack. Pure P.try get's executed on this tick, but we wanna
+        // wrap it in metrics and access checks and start execution only afterwards.
+        // This will go away when filters are completed.
+        var reqHandlerPromise = P.resolve()
+        .then(function() {
+            return reqHandler(childHyperSwitch, childReq);
+        });
 
         reqHandlerPromise = reqHandlerPromise
         .then(function(res) {

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -335,8 +335,7 @@ HyperSwitch.prototype._request = function(req, options) {
         if (match.filters) {
             var specInfo = {
                 path: match.value.path,
-                spec: handler.spec,
-                id: handler.id
+                spec: handler.spec
             };
 
             for (var idx = match.filters.length - 1; idx >= 0; idx--) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,8 +5,8 @@ var yaml = require('js-yaml');
 var fs = P.promisifyAll(require('fs'));
 var handlerTemplate = require('./handlerTemplate');
 var swaggerRouter = require('swagger-router');
-var Validator = require('./validator');
 var path = require('path');
+var uuid = require('cassandra-uuid').Uuid;
 
 var Node = swaggerRouter.Node;
 var Template = swaggerRouter.Template;
@@ -97,6 +97,50 @@ Router.prototype._requireModule = function(modName) {
     }
 };
 
+Router.prototype._expandOptions = function(def, globals) {
+    // Expand options in the parent context, so that config options can be
+    // passed down the chain.
+    var options = {};
+    if (def.options) {
+        // Protect "templates" property from expansion.
+        var templates = def.options.templates;
+        delete def.options.templates;
+        options = new Template(def.options).expand(globals) || {};
+        // Add the original "templates" property back.
+        options.templates = templates;
+    }
+
+    // Append the log property to module options, if it is not present
+    if (!options.log) {
+        options.log = this._options.log || function() {};
+    }
+    return options;
+};
+
+Router.prototype._loadRequestFilter = function(filterDef, globals, method) {
+    if (filterDef.type === 'default') {
+        filterDef.path = __dirname + '/filters/' + filterDef.name + '.js';
+    }
+
+    return {
+        filter: this._requireModule(filterDef.path),
+        options: this._expandOptions(filterDef, globals),
+        method: method
+    };
+};
+
+Router.prototype._loadRequestFilters = function(node, spec, scope, method) {
+    var self = this;
+    var filtersDef = spec['x-request-filters'];
+    if (Array.isArray(filtersDef)) {
+        var filters = filtersDef.map(function(filterDef) {
+            return self._loadRequestFilter(filterDef, scope.globals, method);
+        });
+        node.value = node.value || {};
+        node.value.filters = [].concat(node.value.filters || [], filters);
+    }
+};
+
 /**
  * Load and initialize a module
  */
@@ -152,22 +196,7 @@ Router.prototype._loadModule = function(modDef, globals) {
                 + modDef.type + ' (for module ' + (modDef.name || modDef) + ').');
     }
 
-    // Expand options in the parent context, so that config options can be
-    // passed down the chain.
-    var options = {};
-    if (modDef.options) {
-        // Protect "templates" property from expansion.
-        var templates = modDef.options.templates;
-        delete modDef.options.templates;
-        options = new Template(modDef.options).expand(globals) || {};
-        // Add the original "templates" property back.
-        options.templates = templates;
-    }
-
-    // Append the log property to module options, if it is not present
-    if (!options.log) {
-        options.log = this._options.log || function() {};
-    }
+    var options = this._expandOptions(modDef, globals);
 
     function constructModule(spec) {
         var mod = {
@@ -282,29 +311,30 @@ Router.prototype._registerMethods = function(node, pathspec, scope) {
             }).concat(node.value.security || []);
         }
 
-        var backendSetup = method && method['x-setup-handler'];
+        var backendSetup = method['x-setup-handler'];
         if (backendSetup) {
             Array.prototype.push.apply(node.value.resources,
                 handlerTemplate.parseSetupConfig(backendSetup));
         }
 
-        var backendRequest = method && method['x-request-handler'];
+        var reqHandler;
+        var backendRequest = method['x-request-handler'];
         if (backendRequest) {
-            node.value.methods[methodName] = handlerTemplate.createHandler(backendRequest, {
+            reqHandler = handlerTemplate.createHandler(backendRequest, {
                 globals: node.value.globals,
             });
         } else if (method.operationId) {
-            var handler = scope.operations[method.operationId];
-            if (handler) {
-                node.value.methods[methodName] = handler;
-            } else {
+            reqHandler = scope.operations[method.operationId];
+            if (!reqHandler) {
                 throw new Error('No known handler associated with operationId '
                     + method.operationId);
             }
         }
 
-        if (method && method.parameters && node.value.methods[methodName]) {
-            node.value.methods[methodName].validator = new Validator(method.parameters);
+        if (reqHandler) {
+            node.value.methods[methodName] = reqHandler;
+            node.value.methods[methodName].spec = method;
+            node.value.methods[methodName].id = uuid.random();
         }
     });
 };
@@ -481,6 +511,9 @@ Router.prototype._handleSwaggerSpec = function(node, spec, scope, parentSegment)
     }
     Object.assign(scope.specRoot.definitions, spec.definitions || {});
     Object.assign(scope.specRoot.securityDefinitions, spec.securityDefinitions || {});
+
+    this._loadRequestFilters(node, spec, scope);
+
     return this._handlePaths(node, spec, scope);
 };
 
@@ -531,6 +564,12 @@ Router.prototype.loadSpec = function(spec, hyper) {
             options: hyper.config
         }
     });
+
+    // First load default request filters
+    // TODO: Do that in a cleaner way
+    spec['x-request-filters'] = spec['x-request-filters'] || [];
+    spec['x-request-filters'].push({ type: 'default', name: 'validator' });
+    spec['x-request-filters'].push({ type: 'default', name: 'metrics' });
     return self._handleSwaggerSpec(rootNode, spec, scope)
     .then(function() {
         // Only set the tree after loading everything

--- a/lib/router.js
+++ b/lib/router.js
@@ -6,7 +6,6 @@ var fs = P.promisifyAll(require('fs'));
 var handlerTemplate = require('./handlerTemplate');
 var swaggerRouter = require('swagger-router');
 var path = require('path');
-var uuid = require('cassandra-uuid').Uuid;
 
 var Node = swaggerRouter.Node;
 var Template = swaggerRouter.Template;
@@ -334,7 +333,6 @@ Router.prototype._registerMethods = function(node, pathspec, scope) {
         if (reqHandler) {
             node.value.methods[methodName] = reqHandler;
             node.value.methods[methodName].spec = method;
-            node.value.methods[methodName].id = uuid.random();
         }
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jsonwebtoken": "^5.5.4",
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.8",
-    "swagger-router": "^0.4.0",
+    "swagger-router": "^0.4.1",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "ajv": "^3.7.2"

--- a/test/filters/validator.js
+++ b/test/filters/validator.js
@@ -225,7 +225,11 @@ describe('Validator filter', function () {
 
     it('Should list options for enum errors', function() {
         try {
-            testValidator([
+            testValidator({
+                query: {
+                    queryParam: 'four'
+                }
+            }, [
                 {
                     name: 'queryParam',
                     in: 'query',
@@ -233,11 +237,7 @@ describe('Validator filter', function () {
                     enum: [ 'one', 'two', 'three' ],
                     required: 'true'
                 }
-            ], {
-                query: {
-                    queryParam: 'four'
-                }
-            });
+            ]);
             throw new Error('Should throw error');
         } catch (e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');

--- a/test/filters/validator.js
+++ b/test/filters/validator.js
@@ -3,90 +3,103 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, it, before, beforeEach, after, afterEach */
 
-var assert = require('./utils/assert.js');
-var Validator = require('../lib/validator');
+var assert = require('./../utils/assert.js');
+var validator = require('../../lib/filters/validator');
 
-describe('Validator', function() {
+var testValidator = function (req, parameters) {
+    return validator(null, req, function () {
+    }, null, {
+        spec: {
+            parameters: parameters
+        }
+    });
+};
 
-    it('Should validate request for required fields', function() {
-        var validator = new Validator([{
-            name: 'testParam',
-            in: 'formData',
-            required: true
-        }]);
+describe('Validator filter', function () {
+
+    it('Should validate request for required fields', function () {
         try {
-            validator.validate({
+            testValidator({
                 body: {
                     otherParam: 'test'
                 }
-            });
+            }, [{
+                name: 'testParam',
+                in: 'formData',
+                required: true
+            }]);
             throw new Error('Error should be thrown');
-        } catch(e) {
+        } catch (e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
             assert.deepEqual(e.body.detail, "data.body should have required property 'testParam'");
         }
     });
 
-    it('Should compile validator with no required fields', function() {
-        new Validator([{
+    it('Should compile validator with no required fields', function () {
+        testValidator({
+            body: {}
+        }, [{
             name: 'testParam',
             in: 'formData'
         }]);
     });
 
-    it('Should validate integers', function() {
-        var validator = new Validator([{
-            name: 'testParam',
-            in: 'query',
-            type: 'integer',
-            required: true
-        }]);
+    it('Should validate integers', function () {
         try {
-            validator.validate({
+            testValidator({
                 query: {
                     testParam: 'not_an_integer'
                 }
-            });
+            }, [{
+                name: 'testParam',
+                in: 'query',
+                type: 'integer',
+                required: true
+            }]);
             throw new Error('Error should be thrown');
-        } catch(e) {
+        } catch (e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
             assert.deepEqual(e.body.detail, 'data.query.testParam should be an integer');
         }
     });
 
-    it('Should validate object schemas', function() {
-        var validator = new Validator([{
-            name: 'testParam',
-            in: 'body',
-            schema: {
-                type: 'object',
-                properties: {
-                    field1: {
-                        type: 'string'
-                    },
-                    field2: {
-                        type: 'string'
-                    }
-                },
-                required: ['field1', 'field2']
-            },
-            required: true
-        }]);
+    it('Should validate object schemas', function () {
         try {
-            validator.validate({
+            testValidator({
                 body: {
                     field1: 'some string'
                 }
-            });
+            }, [{
+                name: 'testParam',
+                in: 'body',
+                schema: {
+                    type: 'object',
+                    properties: {
+                        field1: {
+                            type: 'string'
+                        },
+                        field2: {
+                            type: 'string'
+                        }
+                    },
+                    required: ['field1', 'field2']
+                },
+                required: true
+            }]);
             throw new Error('Error should be thrown');
-        } catch(e) {
+        } catch (e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
             assert.deepEqual(e.body.detail, "data.body should have required property 'field2'");
         }
     });
 
-    it('Should allow floats in number validator', function() {
-        var validator = new Validator([
+    it('Should allow floats in number validator', function () {
+        testValidator({
+            query: {
+                testParam1: '27.5',
+                testParam2: '27,5'
+            }
+        }, [
             {
                 name: 'testParam1',
                 in: 'query',
@@ -100,23 +113,9 @@ describe('Validator', function() {
                 required: true
             }
         ]);
-        validator.validate({
-            query: {
-                testParam1: '27.5',
-                testParam2: '27,5'
-            }
-        });
     });
 
-    it('Should coerce boolean parameters', function() {
-        var validator = new Validator([
-            { name: 'boolParamTrue', in: 'query', type: 'boolean' },
-            { name: 'boolParamTrueUpperCase', in: 'query', type: 'boolean' },
-            { name: 'boolParamFalse', in: 'query', type: 'boolean' },
-            { name: 'boolParamFalseUpperCase', in: 'query', type: 'boolean' },
-            { name: 'boolParam0', in: 'query', type: 'boolean' },
-            { name: 'boolParam1', in: 'query', type: 'boolean' },
-        ]);
+    it('Should coerce boolean parameters', function () {
         var req = {
             query: {
                 boolParamTrue: 'true',
@@ -127,7 +126,14 @@ describe('Validator', function() {
                 boolParam1: '1'
             }
         };
-        validator.validate(req);
+        testValidator(req, [
+            {name: 'boolParamTrue', in: 'query', type: 'boolean'},
+            {name: 'boolParamTrueUpperCase', in: 'query', type: 'boolean'},
+            {name: 'boolParamFalse', in: 'query', type: 'boolean'},
+            {name: 'boolParamFalseUpperCase', in: 'query', type: 'boolean'},
+            {name: 'boolParam0', in: 'query', type: 'boolean'},
+            {name: 'boolParam1', in: 'query', type: 'boolean'},
+        ]);
         assert.deepEqual(req.query.boolParamTrue, true);
         assert.deepEqual(req.query.boolParamTrueUpperCase, true);
         assert.deepEqual(req.query.boolParamFalse, false);
@@ -136,70 +142,74 @@ describe('Validator', function() {
         assert.deepEqual(req.query.boolParam1, true);
     });
 
-    it('Should not coerce string parameters', function() {
-        var validator = new Validator([
-            { name: 'stringParam', in: 'query', type: 'string' }
-        ]);
+    it('Should not coerce string parameters', function () {
         var req = {
             query: {
                 stringParam: 'true'
             }
         };
-        validator.validate(req);
+        testValidator(req, [
+            {name: 'stringParam', in: 'query', type: 'string'}
+        ]);
         assert.deepEqual(req.query.stringParam, 'true');
     });
 
-    it('Should not coerce formData for application/json', function() {
-        var validator = new Validator([
-            {name: 'bodyParam', in: 'formData', type: 'boolean', required: true}
-        ]);
+    it('Should not coerce formData for application/json', function () {
         try {
             // The type is incorrect, but wouldn't be coerced, so error will be thrown
-            validator.validate({
+            testValidator({
                 headers: {
                     'content-type': 'application/json'
                 },
                 body: {
                     bodyParam: 'true'
                 }
-            });
+            }, [
+                {name: 'bodyParam', in: 'formData', type: 'boolean', required: true}
+            ]);
             throw new Error('Should throw error');
         } catch (e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
             assert.deepEqual(e.body.detail, "data.body.bodyParam should be boolean");
         }
         // Now all is fine, shouldn't throw an error
-        validator.validate({
+        testValidator({
             headers: {
                 'content-type': 'application/json'
             },
             body: {
                 bodyParam: true
             }
-        });
+        }, [
+            {name: 'bodyParam', in: 'formData', type: 'boolean', required: true}
+        ]);
         // Without 'application/json' coercion should be applied
-        var req = validator.validate({
+        var req = {
             body: {
                 bodyParam: 'true'
             }
-        });
+        };
+        testValidator(req, [
+            {name: 'bodyParam', in: 'formData', type: 'boolean', required: true}
+        ]);
         assert.deepEqual(req.body.bodyParam, true);
     });
 
-    it('Should accept body params without a schema and type', function() {
-        var validator = new Validator([
-            {name: 'bodyParam', in: 'body', required: true}
-        ]);
-        validator.validate({
+    it('Should accept body params without a schema and type', function () {
+        testValidator({
             body: {
                 test: 'test'
             }
-        });
+        }, [
+            {name: 'bodyParam', in: 'body', required: true}
+        ]);
         try {
             // The type is incorrect, but wouldn't be coerced, so error will be thrown
-            validator.validate({
+            testValidator({
                 body: 'This is a string, and body param must be an object'
-            });
+            }, [
+                {name: 'bodyParam', in: 'body', required: true}
+            ]);
             throw new Error('Should throw error');
         } catch (e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
@@ -207,25 +217,23 @@ describe('Validator', function() {
         }
     });
 
-    it('Should allow non-required body', function() {
-        var validator = new Validator([
+    it('Should allow non-required body', function () {
+        testValidator({}, [
             {name: 'bodyParam', in: 'body'}
         ]);
-        validator.validate({});
     });
 
     it('Should list options for enum errors', function() {
-        var validator = new Validator([
-            {
-                name: 'queryParam',
-                in: 'query',
-                type: 'string',
-                enum: [ 'one', 'two', 'three' ],
-                required: 'true'
-            }
-        ]);
         try {
-            validator.validate({
+            testValidator([
+                {
+                    name: 'queryParam',
+                    in: 'query',
+                    type: 'string',
+                    enum: [ 'one', 'two', 'three' ],
+                    required: 'true'
+                }
+            ], {
                 query: {
                     queryParam: 'four'
                 }


### PR DESCRIPTION
A first and primary implementation for request filters. Converted validation and metrics wrapping into default filters. There's still lots of work to be done, but lets move gradually to avoid deploying giant changes in one run.

cc @wikimedia/services 