### PR TITLE
Validation: Include allowed values into error messages

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -44,7 +44,7 @@ var supportedValidators = ['maximum',
  * @constructor
  */
 var Validator = function(parameters) {
-    this._ajv = constructAjv();
+    this._ajv = constructAjv({ verbose: true });
     this._paramCoercionFunc = this._createTypeCoercionFunc(parameters.filter(function(p) {
         return p.in !== 'formData' && p.in !== 'body' && p.type !== 'string';
     }));
@@ -184,12 +184,20 @@ Validator.prototype.validate = function(req) {
         req = this._bodyCoercionFunc(req, HTTPError);
     }
     if (!this._validatorFunc(req)) {
+        var message;
+        var error = this._validatorFunc.errors[0];
+        if (error.keyword === 'enum') {
+            message = 'data' + error.dataPath + ' ' +
+                    error.message + ': [' + error.schema.join(', ') + ']';
+        } else {
+            message = this._ajv.errorsText(this._validatorFunc.errors);
+        }
         throw new HTTPError({
             status: 400,
             body: {
                 type: 'bad_request',
                 title: 'Invalid parameters',
-                detail: this._ajv.errorsText(this._validatorFunc.errors),
+                detail: message,
                 req: req
             }
         });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "swagger-router": "^0.4.0",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "ajv": "^3.4.0"
+    "ajv": "^3.7.2"
   },
   "devDependencies": {
     "coveralls": "^2.11.6",

--- a/test/validator.js
+++ b/test/validator.js
@@ -212,5 +212,29 @@ describe('Validator', function() {
             {name: 'bodyParam', in: 'body'}
         ]);
         validator.validate({});
-    })
+    });
+
+    it('Should list options for enum errors', function() {
+        var validator = new Validator([
+            {
+                name: 'queryParam',
+                in: 'query',
+                type: 'string',
+                enum: [ 'one', 'two', 'three' ],
+                required: 'true'
+            }
+        ]);
+        try {
+            validator.validate({
+                query: {
+                    queryParam: 'four'
+                }
+            });
+            throw new Error('Should throw error');
+        } catch (e) {
+            assert.deepEqual(e.constructor.name, 'HTTPError');
+            assert.deepEqual(e.body.detail, "data.query.queryParam should be equal to " +
+                "one of the allowed values: [one, two, three]");
+        }
+    });
 });


### PR DESCRIPTION
We have to show the list of allowed values in the error message if the enum constraint was failed.

https://phabricator.wikimedia.org/T126929

cc @wikimedia/services