### PR TITLE
Tests: Remove obsolete salt test

### DIFF
--- a/test/hyperswitch/hyperswitch.js
+++ b/test/hyperswitch/hyperswitch.js
@@ -184,37 +184,6 @@ describe('HyperSwitch context', function() {
         });
     });
 
-    it('requires salt in the config', function() {
-        try {
-            main({
-                appBasePath: __dirname + '/../../',
-                config: {
-                    port: 12346,
-                    spec: simpleSpec
-                }
-            });
-            throw new Error('Should throw error on invalid salt');
-        } catch (e) {
-            assert.deepEqual(e.message,
-                'Missing or invalid `salt` option in HyperSwitch config. Expected a string.')
-        }
-
-        try {
-            main({
-                appBasePath: __dirname + '/../../',
-                config: {
-                    salt: 1,
-                    port: 12346,
-                    spec: simpleSpec
-                }
-            });
-            throw new Error('Should throw error on invalid salt');
-        } catch (e) {
-            assert.deepEqual(e.message,
-            'Missing or invalid `salt` option in HyperSwitch config. Expected a string.')
-        }
-    });
-
     it('Should strip out hop-to-hop headers', function() {
         return preq.get({
             uri: server.hostPort + '/service/hop_to_hop'


### PR DESCRIPTION
wikimedia/hyperswitch#5 removed the token (en/de)coding functionality, but a stray test verifying it has been left behind. This PR just removes it, as HyperSwitch does not require the salt configuration variable to be present any longer.