### PR TITLE
Point error types to mediawiki.org

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -189,7 +189,7 @@ function handleResponse(opts, req, resp, response) {
                 title: rBody.title,
                 method: rBody.method || req.method,
                 detail: rBody.detail || rBody.description,
-                instance: rBody.instance || rBody.uri || req.uri
+                uri: rBody.uri || req.uri
             };
             if (response.status === 404) {
                 body.type = body.type || 'not_found';

--- a/lib/server.js
+++ b/lib/server.js
@@ -179,34 +179,30 @@ function handleResponse(opts, req, resp, response) {
         var body;
         // Prepare error responses for the client
         if (response.status >= 400) {
-            if (!response.body) {
-                response.body = {};
-            }
-            // Whitelist fields to avoid leaking sensitive info
-            var rBody = response.body;
-            body = {
-                type: rBody.type,
-                title: rBody.title,
-                method: rBody.method,
-                detail: rBody.detail || rBody.description,
-                uri: rBody.uri
-            };
-
             rh['content-type'] = rh['content-type']
                 || 'application/problem+json';
 
+            // Whitelist fields to avoid leaking sensitive info
+            var rBody = response.body || {};
+            body = {
+                type: rBody.type,
+                title: rBody.title,
+                method: rBody.method || req.method,
+                detail: rBody.detail || rBody.description,
+                instance: rBody.instance || rBody.uri || req.uri
+            };
             if (response.status === 404) {
                 body.type = body.type || 'not_found';
                 body.title = body.title || 'Not found.';
             }
-
-            body.uri = body.uri || req.uri;
-            body.method = body.method || req.method;
             body.type = body.type || 'unknown_error';
 
             // Prefix error base URL
-            // TODO: make the prefix configurable
-            body.type = 'https://restbase.org/errors/' + body.type;
+            if (!/^https?:\/\//.test(body.type)) {
+                body.type = (opts.conf.default_error_uri
+                        || 'https://mediawiki.org/wiki/HyperSwitch/errors/')
+                    + body.type;
+            }
             response.body = body;
         }
 

--- a/test/hyperswitch/hyperswitch.js
+++ b/test/hyperswitch/hyperswitch.js
@@ -73,10 +73,10 @@ describe('HyperSwitch context', function() {
             assert.deepEqual(e.status, 404);
             assert.deepEqual(e.headers['content-type'], 'application/problem+json');
             assert.deepEqual(e.body, {
-                type: 'https://restbase.org/errors/not_found#route',
+                type: 'https://mediawiki.org/wiki/HyperSwitch/errors/not_found#route',
                 title: 'Not found.',
                 method: 'get',
-                uri: '/this_path_does_not_exist/'
+                instance: '/this_path_does_not_exist/'
             });
         });
     });
@@ -88,7 +88,7 @@ describe('HyperSwitch context', function() {
         }, function(e) {
             assert.deepEqual(e.status, 400);
             assert.deepEqual(e.headers['content-type'], 'application/problem+json');
-            assert.deepEqual(e.body.uri, '/service/no_response');
+            assert.deepEqual(e.body.instance, '/service/no_response');
         });
     });
 

--- a/test/hyperswitch/hyperswitch.js
+++ b/test/hyperswitch/hyperswitch.js
@@ -76,7 +76,7 @@ describe('HyperSwitch context', function() {
                 type: 'https://mediawiki.org/wiki/HyperSwitch/errors/not_found#route',
                 title: 'Not found.',
                 method: 'get',
-                instance: '/this_path_does_not_exist/'
+                uri: '/this_path_does_not_exist/'
             });
         });
     });
@@ -88,7 +88,7 @@ describe('HyperSwitch context', function() {
         }, function(e) {
             assert.deepEqual(e.status, 400);
             assert.deepEqual(e.headers['content-type'], 'application/problem+json');
-            assert.deepEqual(e.body.instance, '/service/no_response');
+            assert.deepEqual(e.body.uri, '/service/no_response');
         });
     });
 


### PR DESCRIPTION
Prefix errors with path to mediawiki.org docs, made prefix configurable, renamed `uri` property to `instance` to better conform [RFC](http://tools.ietf.org/html/draft-nottingham-http-problem-07)

Bug: https://phabricator.wikimedia.org/T128415

cc @wikimedia/services 