### PR TITLE
Add ratelimit_group filter

### DIFF
--- a/lib/filters/ratelimit_route.js
+++ b/lib/filters/ratelimit_route.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// Simple per-route rate limiter.
+
+module.exports = function(hyper, req, next, options, specInfo) {
+    if (!hyper.ratelimiter) {
+        return next(hyper, req);
+    }
+
+    var requestClass = hyper._rootReq.headers['x-request-class'];
+    if (!options || !options.limits || !options.limits[requestClass]) {
+        return next(hyper, req);
+    }
+
+    // By default, ignore the domain for limiting purposes.
+    var pathKey = hyper.config.service_name + '.'
+                    + specInfo.path.replace(/\/[^\/]+\//, '') + '.'
+                    + req.method.toUpperCase();
+
+    var key = pathKey + '|' + hyper._rootReq.headers['x-client-ip'];
+    if (hyper.ratelimiter.isAboveLimit(key, options.limits[requestClass])) {
+        // TODO: Actually throw an HTTPError once we have verified limits to
+        // work well.
+        hyper.log('warn/ratelimit/' + pathKey, {
+            key: key,
+            limit: options.limits[requestClass],
+            message: 'Rate limit exceeded'
+        });
+    }
+    return next(hyper, req);
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -286,29 +286,12 @@ function handleRequest(opts, req, resp) {
 
     var reqOpts = {
         conf: opts.conf,
-        logger: opts.logger && opts.logger.child({
-            root_req: {
-                method: req.method.toLowerCase(),
-                uri: req.url,
-                headers: {
-                    'cache-control': req.headers['cache-control'],
-                    'content-length': req.headers['content-length'],
-                    'content-type': req.headers['content-type'],
-                    'if-match': req.headers['if-match'],
-                    'user-agent': req.headers['user-agent'],
-                    'x-client-ip': req.headers['x-client-ip'],
-                    'x-request-id': req.headers['x-request-id'],
-                },
-            },
-            request_id: req.headers['x-request-id']
-        }),
         log: null,
         reqId: req.headers['x-request-id'],
         metrics: opts.metrics,
         ratelimiter: opts.ratelimiter,
         startTime: Date.now()
     };
-    reqOpts.log = reqOpts.logger && reqOpts.logger.log.bind(reqOpts.logger) || function() {};
 
     /**
      * We use separate metric trees for requests from private networks, so
@@ -321,12 +304,35 @@ function handleRequest(opts, req, resp) {
     if (/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
         if (req.headers['cache-control'] && /no-cache/i.test(req.headers['cache-control'])) {
             reqOpts.metrics = opts.child_metrics.internal_update;
+            req.headers['x-request-class'] = 'internal_update';
         } else {
             reqOpts.metrics = opts.child_metrics.internal;
+            req.headers['x-request-class'] = 'internal';
         }
     } else {
         reqOpts.metrics = opts.child_metrics.external;
+        req.headers['x-request-class'] = 'external';
     }
+
+    // Create a child logger with selected request information.
+    reqOpts.logger = opts.logger && opts.logger.child({
+        root_req: {
+            method: req.method.toLowerCase(),
+            uri: req.url,
+            headers: {
+                'cache-control': req.headers['cache-control'],
+                'content-length': req.headers['content-length'],
+                'content-type': req.headers['content-type'],
+                'if-match': req.headers['if-match'],
+                'user-agent': req.headers['user-agent'],
+                'x-client-ip': req.headers['x-client-ip'],
+                'x-request-id': req.headers['x-request-id'],
+                'x-request-class': req.headers['x-request-class'],
+            },
+        },
+        request_id: req.headers['x-request-id']
+    });
+    reqOpts.log = reqOpts.logger && reqOpts.logger.log.bind(reqOpts.logger) || function() {};
 
     // Create a new, clean request object
     var urlData = parseURL(req.url);
@@ -402,6 +408,7 @@ function handleRequest(opts, req, resp) {
 function main(options) {
     var conf = options.config || {};
     // Set up the global options object with a logger
+    conf.service_name = options.name;
     var opts = {
         appBasePath: options.appBasePath,
         conf: conf,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "mocha-jshint": "^2.2.6",
     "mocha-lcov-reporter": "^1.0.0",
     "nock": "^5.2.1",
-    "service-runner": "^1.1.0"
+    "service-runner": "^1.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/hyperswitch/filters.js
+++ b/test/hyperswitch/filters.js
@@ -5,6 +5,14 @@ var Server = require('../utils/server.js');
 var preq   = require('preq');
 var P      = require('bluebird');
 
+function range(n) {
+    var a = new Array(n);
+    for (var i = 0; i < n; i++) {
+        a[i] = i;
+    }
+    return a;
+}
+
 describe('Documentation handling', function() {
     var server = new Server('test/hyperswitch/filters_config.yaml');
 
@@ -39,6 +47,36 @@ describe('Documentation handling', function() {
             assert.deepEqual(res.body.toString(), 'From Handler');
         });
     });
+
+    // Rate limits
+    it('Should allow low-volume access', function () {
+        return P.each(range(10), function() {
+            return preq.get({
+                uri: server.hostPort + '/limited'
+            })
+            .delay(1200);
+        });
+    });
+
+    // Disabled until the rate limiter actually throws.
+    //
+    // it('Should block high-volume access', function () {
+    //     var limited = 0;
+    //     return P.each(range(30), function() {
+    //         return preq.get({
+    //             uri: server.hostPort + '/limited'
+    //         })
+    //         .catch(function() {
+    //             limited++;
+    //         })
+    //         .delay(500);
+    //     }).then(function() {
+    //         if (limited < 1) {
+    //             throw new Error('Should have limited!');
+    //         }
+    //     });
+
+    // });
 
     after(function() { return server.stop(); });
 });

--- a/test/hyperswitch/filters_config.yaml
+++ b/test/hyperswitch/filters_config.yaml
@@ -11,6 +11,19 @@ spec_root: &spec_root
               return:
                 status: 200
                 body: 'From Handler'
+    /limited:
+      get:
+        x-route-filters:
+          - type: default
+            name: ratelimit_route
+            options:
+              limits:
+                internal: 1
+        x-request-handler:
+          - return_result:
+              return:
+                status: 200
+                body: 'From limited handler'
     /non_filtered:
       get:
         x-request-handler:


### PR DESCRIPTION
- Add a per-route & client IP rate limiter. For now, this only logs a warning
  when the limit is exceeded. Once we have tested this properly, it will throw
  an HTTPError instead.

  Limits can be defined per request class:
  ```yaml
  x-route-filters:
    - type: default
      name: ratelimit_route
      options:
        limits:
          external: 200
  ```
- Forward the service name as config.service_name.
- Forward the request class in a header.