### PR TITLE
Improve web request matching

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -281,8 +281,8 @@ HyperSwitch.prototype._request = function(req, options) {
     var self = this;
 
     // Special handling for https? requests
-    if (req.uri.constructor === String && /^https?:\/\//.test(req.uri)
-            || req.uri.urlObj) {
+    var host = req.uri.constructor === String ? req.uri : req.uri.protoHost;
+    if (/^https?:\/\//.test(host)) {
         return self.defaultWebRequestHandler(req);
     }
 

--- a/test/hyperswitch/hyperswitch.js
+++ b/test/hyperswitch/hyperswitch.js
@@ -208,7 +208,7 @@ describe('HyperSwitch context', function() {
 
     it('Should not gzip already gzipped content', function() {
         return preq.get({
-            uri: server.hostPort + '/service/gzip/get'
+            uri: server.hostPort + '/service/module/gzip'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
@@ -218,7 +218,7 @@ describe('HyperSwitch context', function() {
 
     it('Should unzip content if it is not accepted', function() {
         return preq.get({
-            uri: server.hostPort + '/service/gzip/get',
+            uri: server.hostPort + '/service/module/gzip',
             headers: {
                 'accept-encoding': 'identity'
             },
@@ -228,6 +228,15 @@ describe('HyperSwitch context', function() {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers.hasOwnProperty('content-encoding'), false);
             assert.deepEqual(res.body.toString(), 'TEST');
+        });
+    });
+
+    it('Should get remote content with URI', function() {
+        return preq.get({
+            uri: server.hostPort + '/service/module/remote'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
         });
     });
 

--- a/test/hyperswitch/js_module.js
+++ b/test/hyperswitch/js_module.js
@@ -2,20 +2,26 @@
 
 var P = require('bluebird');
 var zlib = require('zlib');
+var URI = require('../../lib/exports').URI;
 
 module.exports = function() {
     return {
         spec: {
             paths: {
-                '/get': {
+                '/gzip': {
                     get: {
-                        operationId: 'getContent'
+                        operationId: 'gzipContent'
+                    }
+                },
+                '/remote': {
+                    get: {
+                        operationId: 'remoteContent'
                     }
                 }
             }
         },
         operations: {
-            getContent: function() {
+            gzipContent: function() {
                 var zStream = zlib.createGzip({ level: 5 });
                 zStream.end('TEST');
                 return P.resolve({
@@ -24,6 +30,11 @@ module.exports = function() {
                         'content-encoding': 'gzip'
                     },
                     body: zStream
+                });
+            },
+            remoteContent: function(hyper) {
+                return hyper.get({
+                    uri: new URI('https://en.wikipedia.org/wiki/Darth_Vader')
                 });
             }
         }

--- a/test/hyperswitch/test_config.yaml
+++ b/test/hyperswitch/test_config.yaml
@@ -76,9 +76,9 @@ spec_root: &spec_root
               request:
                 uri: https://en.wikipedia.org/wiki/Main_Page
 
-    /service/gzip:
+    /service/module:
       x-modules:
-        - path: test/hyperswitch/gzipping_module.js
+        - path: test/hyperswitch/js_module.js
 
 # Finally, a standard service-runner config.
 info:


### PR DESCRIPTION
Before requests like
```javascript
return hyper.get({ uri: new URI('https://en.wikipedia.org/wiki/Darth_Vader') });
```
didn't work because matching for a remote URI was wrong.

cc @wikimedia/services 
