### PR TITLE
Converted the header_match security stanza to a filter

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -120,57 +120,6 @@ var securityDefinitionCreators = {
                 });
             }
         };
-    },
-    header_match: function(definition) {
-        var errorMessage = definition['x-error-message']
-            || 'This client is not allowed to use the endpoint';
-        var whitelistMap = {};
-        Object.keys(definition['x-whitelists']).forEach(function(whitelistName) {
-            whitelistMap[whitelistName]
-                = constructInternalRequestRegex(definition['x-whitelists'][whitelistName]);
-        });
-
-        return {
-            prepareRequest: function() {
-            },
-            checkPermissions: function(hyper, req, permissions) {
-                if (hyper._rootReq.uri === '#internal-startup') {
-                    // Skip a check on requests made by HyperSwitch during startup
-                    return;
-                }
-
-                permissions.forEach(function(requirementDefinition) {
-                    // Check if requirement is limited to some method
-                    if (requirementDefinition.method
-                            && requirementDefinition.method !== req.method) {
-                        return;
-                    }
-
-                    var headerMatchRequirement = requirementDefinition.value;
-                    var headerName = headerMatchRequirement.header;
-                    var headerValue = req.headers && req.headers[headerName]
-                            || hyper._rootReq.headers && hyper._rootReq.headers[headerName];
-
-                    headerMatchRequirement.patterns.forEach(function(patternName) {
-                        if (!whitelistMap[patternName]) {
-                            throw new Error('Invalid spec. ' +
-                            'Unknown client ip whitelist name: ' + patternName);
-                        }
-
-                        if (!whitelistMap[patternName].test(headerValue)) {
-                            throw new HTTPError({
-                                status: 403,
-                                body: {
-                                    type: 'forbidden',
-                                    title: 'Access to resource denied',
-                                    description: errorMessage
-                                }
-                            });
-                        }
-                    });
-                });
-            }
-        };
     }
 };
 

--- a/lib/filters/header_match.js
+++ b/lib/filters/header_match.js
@@ -1,0 +1,51 @@
+"use strict";
+
+var HTTPError = require('../exports').HTTPError;
+
+/**
+ * From a list of uri Regex and values, constructs a regex to check if the
+ * request URI is in the white-list.
+ */
+var CACHE = new Map();
+function constructInternalRequestRegex(variants) {
+    if (CACHE.has(variants)) {
+        return CACHE.get(variants);
+    }
+    var regex = (variants || []).map(function(regexString) {
+        if (/^\/.+\/$/.test(regexString)) {
+            return '(:?' + regexString.substring(1, regexString.length - 1) + ')';
+        } else {
+            // Instead of comparing strings
+            return '(:?^'
+                + regexString.replace(/[\-\[\]\/\{}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
+                + '$)';
+        }
+    }).join('|');
+    regex = regex && regex.length > 0 ? new RegExp(regex) : undefined;
+    CACHE.set(variants, regex);
+    return regex;
+}
+
+module.exports = function(hyper, req, next, options) {
+    var errorMessage = options.error_message
+        || 'This client is not allowed to use the endpoint';
+    // Skip a check on requests made by HyperSwitch during startup
+    if (hyper._rootReq.uri !== '#internal-startup') {
+        Object.keys(options.whitelist).forEach(function(headerName) {
+            var valueRegex = constructInternalRequestRegex(options.whitelist[headerName]);
+            var headerValue = req.headers && req.headers[headerName]
+                    || hyper._rootReq.headers && hyper._rootReq.headers[headerName];
+            if (!valueRegex.test(headerValue)) {
+                throw new HTTPError({
+                    status: options.error_status || 403,
+                    body: {
+                        type: 'forbidden',
+                        title: 'Access to resource denied',
+                        detail: errorMessage
+                    }
+                });
+            }
+        });
+    }
+    return next(hyper, req);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/hyperswitch/filters.js
+++ b/test/hyperswitch/filters.js
@@ -48,6 +48,37 @@ describe('Filters', function() {
         });
     });
 
+    it('should allow access if headers matched', function() {
+        return preq.get({
+            uri: server.hostPort + '/header_match_filter',
+            headers: {
+                header_one: 'asdc',
+                header_two: 'test_two',
+                header_three: 'some_random_value'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.toString(), 'From Handler');
+        });
+    });
+
+    it('should restrict access if headers not matched', function() {
+        return preq.get({
+            uri: server.hostPort + '/header_match_filter',
+            headers: {
+                header_one: 'asdc123',
+                header_three: 'some_random_value'
+            }
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 403);
+            assert.deepEqual(e.body.detail, 'Test Message');
+        });
+    });
+
     // Rate limits
     it('Should allow low-volume access', function () {
         return P.each(range(10), function() {

--- a/test/hyperswitch/filters_config.yaml
+++ b/test/hyperswitch/filters_config.yaml
@@ -39,7 +39,24 @@ spec_root: &spec_root
               return:
                 status: 200
                 body: 'From Handler'
-
+    /header_match_filter:
+      get:
+        x-route-filters:
+          - type: 'default'
+            name: 'header_match'
+            options:
+              error_message: 'Test Message'
+              whitelist:
+                header_one:
+                  - 'test_one'
+                  - /^[a-z]+$/
+                header_two:
+                  - 'test_two'
+        x-request-handler:
+          - return_result:
+              return:
+                status: 200
+                body: 'From Handler'
 
 # Finally, a standard service-runner config.
 info:


### PR DESCRIPTION
As a part of an ongoing effort to convert everything to filters.

When the matching capability from change-propagation will become mature and grow to it's own lib, we would be able to change this filter a bit to match on arbitrary properties of a request.

cc @wikimedia/services 