### PR TITLE
Clone request before calling request filters

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -251,39 +251,38 @@ HyperSwitch.prototype.request = function(req, options) {
 };
 
 HyperSwitch.prototype._filteredRequest = function(req, options) {
-    return this._createFilteredHandler(function(hyper, req) {
-        return hyper._request(req, options);
-    }, this._recursionDepth === 0 ? this._requestFilters : this._subRequestFilters)(this, req);
+    this._checkMaxRecursionDepth(req);
+    // Make sure we have a sane & uniform request object that doesn't change
+    // (at least at the top level) under our feet.
+    var childReq = cloneRequest(req);
+    return this._createFilteredHandler(function(hyper, childReq) {
+        return hyper._request(childReq, options);
+    }, this._recursionDepth === 0 ? this._requestFilters : this._subRequestFilters)(this, childReq);
 };
 
 // Process one request
 HyperSwitch.prototype._request = function(req, options) {
     var self = this;
-    self._checkMaxRecursionDepth(req);
-
-    // Make sure we have a sane & uniform request object that doesn't change
-    // (at least at the top level) under our feet.
-    var childReq = cloneRequest(req);
 
     // Look up the route in the tree.
-    var match = this._priv.router.route(childReq.uri);
+    var match = this._priv.router.route(req.uri);
     var handler;
     if (match) {
-        childReq.params = match.params;
-        self._checkInternalApiRequest(childReq);
+        req.params = match.params;
+        self._checkInternalApiRequest(req);
 
         // Find a handler.
         var methods = match.value && match.value.methods || {};
-        handler = methods[childReq.method] || methods.all;
+        handler = methods[req.method] || methods.all;
         if (!handler
-                && (childReq.method === 'head'
+                && (req.method === 'head'
                     || self._rootReq && self._rootReq.method === 'head')) {
             handler = methods && methods.get;
         }
 
         if (!handler
-                && childReq.method === 'get'
-                && childReq.uri.path[childReq.uri.path.length - 1] === '') {
+                && req.method === 'get'
+                && req.uri.path[req.uri.path.length - 1] === '') {
             // A GET for an URL that ends with /: return a default listing
             if (!match.value) { match.value = {}; }
             if (!match.value.path) { match.value.path = '_defaultListingHandler'; }
@@ -295,7 +294,7 @@ HyperSwitch.prototype._request = function(req, options) {
 
     if (handler) {
         // Prepare to call the handler with a child HyperSwitch instance
-        var childHyperSwitch = this.makeChild(childReq, options);
+        var childHyperSwitch = this.makeChild(req, options);
         var reqHandler = childHyperSwitch._createFilteredHandler(handler, match.filters, {
             path: match.value.path,
             spec: handler.spec
@@ -305,7 +304,7 @@ HyperSwitch.prototype._request = function(req, options) {
         // This will go away when filters are completed.
         var reqHandlerPromise = P.resolve()
         .then(function() {
-            return reqHandler(childHyperSwitch, childReq);
+            return reqHandler(childHyperSwitch, req);
         });
 
         return reqHandlerPromise
@@ -329,7 +328,7 @@ HyperSwitch.prototype._request = function(req, options) {
                 var err = new HTTPError(res);
                 if (res.body && res.body.stack) { err.stack = res.body.stack; }
                 err.innerBody = res.body;
-                err.internalReq = childReq;
+                err.internalReq = req;
                 throw err;
             } else {
                 return res;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Ensure all request parts are initialised before calling request filters.

cc @wikimedia/services 