### PR TITLE
Capture and potentially log x-forwarded-for request header; v0.4.3

### DIFF
--- a/lib/filters/validator.js
+++ b/lib/filters/validator.js
@@ -142,11 +142,11 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
                 errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
                     + ' title:"Invalid parameters", detail: "data.'
                     + inMapping[param.in] + '.' + param.name + ' should be a boolean.'
-                    + ' true|false|1|0 is accepted as a boolean."}});\n';
-                paramCoercionCode += 'if(!/^true|false|1|0$/i.test('
+                    + ' true|false|1|0|yes|no is accepted as a boolean."}});\n';
+                paramCoercionCode += 'if(!/^true|false|1|0|yes|no$/i.test('
                     + paramAccessor + ' + "")) {\n'
                     + errorNotifier + '}\n'
-                    + paramAccessor + ' = /^true|1$/i.test('
+                    + paramAccessor + ' = /^true|1|yes$/i.test('
                     + paramAccessor + ' + "");\n';
         }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -319,6 +319,7 @@ function handleRequest(opts, req, resp) {
                 'if-match': req.headers['if-match'],
                 'user-agent': req.headers['user-agent'],
                 'x-client-ip': req.headers['x-client-ip'],
+                'x-forwarded-for': req.headers['x-forwarded-for'],
                 'x-request-id': req.headers['x-request-id'],
                 'x-request-class': req.headers['x-request-class'],
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Also, accept yes|no as boolean values in the parameter validator.