### PR TITLE
Always pass a user-agent from a root request

### DIFF
--- a/lib/filters/http.js
+++ b/lib/filters/http.js
@@ -26,7 +26,9 @@ module.exports = function(hyper, req, next, options) {
 
     // Enforce the usage of UA
     req.headers = req.headers || {};
-    req.headers['user-agent'] = req.headers['user-agent'] || hyper.config.user_agent;
+    req.headers['user-agent'] = hyper._rootReq.headers['user-agent']
+        || req.headers['user-agent']
+        || hyper.config.user_agent;
     hyper.setRequestId(req);
     hyper.log('trace/webrequest', {
         req: req,

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -51,6 +51,7 @@ function HyperSwitch(options, req, parOptions) {
         this._priv = par._priv;
         this.config = this._priv.options.conf;
         this._rootReq = par._rootReq || req;
+        this._rootReq.headers = this._rootReq.headers || {};
         this._requestFilters = par._requestFilters;
         this._subRequestFilters = par._subRequestFilters;
         this.ctx = par.ctx || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {
@@ -43,7 +43,7 @@
     "mocha-jscs": "^4.0.0",
     "mocha-jshint": "^2.2.6",
     "mocha-lcov-reporter": "^1.0.0",
-    "nock": "^5.2.1",
+    "nock": "^8.0.0",
     "service-runner": "^1.1.7"
   }
 }

--- a/test/hyperswitch/hyperswitch.js
+++ b/test/hyperswitch/hyperswitch.js
@@ -3,6 +3,7 @@
 var assert = require('../utils/assert.js');
 var Server = require('../utils/server.js');
 var preq   = require('preq');
+var nock   = require('nock');
 
 var main = require('../../lib/server');
 
@@ -237,6 +238,28 @@ describe('HyperSwitch context', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
+        });
+    });
+
+    it('Should pass User-Agent header', function() {
+        var api = nock('https://en.wikipedia.org', {
+            reqheaders: {
+                'user-agent': 'test_user_agent'
+            }
+        })
+        .get('/wiki/Main_Page').reply(200, {});
+
+        return preq.get({
+            uri: server.hostPort + '/service/hop_to_hop',
+            headers: {
+                'user-agent': 'test_user_agent'
+            }
+        })
+        .then(function() {
+            api.done();
+        })
+        .finally(function() {
+            nock.cleanAll();
         });
     });
 


### PR DESCRIPTION
We need to always pass the `user-agent`, but it's stored in a root request, not in the req.headers.

cc @wikimedia/services 