### PR TITLE
Fix access to sys hierarchi

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -137,6 +137,8 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
                     + '<h2>APIs:</h2>'
                     + '<div class="info_description markdown"><ul>'
                     + req.params._ls.filter(function(item) {
+                            // TODO: This will filter out everything called `sys`,
+                            // not only {api:sys} elements
                             return item !== 'sys';
                         })
                         .map(function(api) {
@@ -161,6 +163,8 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
             status: 200,
             body: {
                 items: req.params._ls.filter(function(item) {
+                    // TODO: This will filter out everything called `sys`,
+                    // not only {api:sys} elements
                     return item !== 'sys';
                 })
             }

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -160,14 +160,16 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
         return P.resolve({
             status: 200,
             body: {
-                items: req.params._ls
+                items: req.params._ls.filter(function(item) {
+                    return item !== 'sys';
+                })
             }
         });
     }
 };
 
 HyperSwitch.prototype._isSysRequest = function(req) {
-    return ((req.uri.params && req.uri.params.api === 'sys')
+    return ((req.params && req.params.api === 'sys')
         // TODO: Remove once params.api is reliable
             || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/hyperswitch/docs.js
+++ b/test/hyperswitch/docs.js
@@ -113,5 +113,30 @@ describe('Documentation handling', function() {
         });
     });
 
+    it('should not list sys api', function () {
+        return preq.get({
+            uri: server.hostPort + '/'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.body, {
+                items: [ 'v1' ]
+            });
+        });
+    });
+
+    it('should not allow doc requests to sys', function () {
+        return preq.get({
+            uri: server.hostPort + '/sys/?doc=',
+            headers: {
+                accept: 'text/html'
+            }
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function (e) {
+            assert.deepEqual(e.status, 403);
+        });
+    });
+
     after(function() { return server.stop(); });
 });

--- a/test/hyperswitch/docs_config.yaml
+++ b/test/hyperswitch/docs_config.yaml
@@ -12,6 +12,19 @@ spec_root: &spec_root
                         return:
                           status: 200
                           body: 'test'
+    /{api:sys}/test/:
+      x-modules:
+        - type: inline
+          spec:
+            paths:
+              /test:
+                get:
+                  x-request-handler:
+                    - return_result:
+                        return:
+                          status: 200
+                          body: 'test'
+
 
 # Finally, a standard service-runner config.
 info:

--- a/test/router/buildTree.js
+++ b/test/router/buildTree.js
@@ -7,7 +7,6 @@ var Router = require('../../lib/router');
 var assert = require('../utils/assert');
 var fs     = require('fs');
 var yaml   = require('js-yaml');
-var URI    = require('swagger-router').URI;
 
 var fakeHyperSwitch = { config: {} };
 
@@ -270,7 +269,7 @@ describe('Router', function() {
                 try {
                     var expectedRequest = {
                         method: 'post',
-                        uri: new URI('/testing/uri/that/will/be/checked/by/test'),
+                        uri: '/testing/uri/that/will/be/checked/by/test',
                         headers: {
                             test: 'test'
                         },


### PR DESCRIPTION
1. Fixed checks for access to sys. The api parameter is actually in the `req.param`, not `req.uri.params`.
2. Don't return sys items in JSON listings
3. After https://github.com/wikimedia/swagger-router/commit/edddfa0b9319a0dc162e5db0ddf010515c3e9fd0 is the URI is not templated it's returned back as a string. It's perfectly fine, but it breaks a test. Fixed the test back.

cc @wikimedia/services 