### PR TITLE
Support enforcing of request limits

### DIFF
--- a/lib/filters/ratelimit_route.js
+++ b/lib/filters/ratelimit_route.js
@@ -31,10 +31,10 @@ module.exports = function(hyper, req, next, options, specInfo) {
             throw new HTTPError({
                 status: 429,
                 body: {
-                   type: 'request_rate_exceeded',
-                   title: 'HyperSwitch request rate limit exceeded',
-                   key: key,
-                   rate_limit_per_second: options.limits[requestClass],
+                    type: 'request_rate_exceeded',
+                    title: 'HyperSwitch request rate limit exceeded',
+                    key: key,
+                    rate_limit_per_second: options.limits[requestClass],
                 }
             });
         }

--- a/lib/filters/ratelimit_route.js
+++ b/lib/filters/ratelimit_route.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var HTTPError = require('../exports').HTTPError;
+
 // Simple per-route rate limiter.
 
 module.exports = function(hyper, req, next, options, specInfo) {
@@ -19,13 +21,23 @@ module.exports = function(hyper, req, next, options, specInfo) {
 
     var key = pathKey + '|' + hyper._rootReq.headers['x-client-ip'];
     if (hyper.ratelimiter.isAboveLimit(key, options.limits[requestClass])) {
-        // TODO: Actually throw an HTTPError once we have verified limits to
-        // work well.
-        hyper.log('warn/ratelimit/' + pathKey, {
-            key: key,
-            limit: options.limits[requestClass],
-            message: 'Rate limit exceeded'
-        });
+        if (options.log_only) {
+            hyper.log('warn/ratelimit/' + pathKey, {
+                key: key,
+                rate_limit_per_second: options.limits[requestClass],
+                message: 'Rate limit exceeded'
+            });
+        } else {
+            throw new HTTPError({
+                status: 429,
+                body: {
+                   type: 'request_rate_exceeded',
+                   title: 'HyperSwitch request rate limit exceeded',
+                   key: key,
+                   rate_limit_per_second: options.limits[requestClass],
+                }
+            });
+        }
     }
     return next(hyper, req);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This patch adds the ability to actually enforce request limits by throwing
appropriate HTTPError instances. A log-only mode is still supported. To enable
this, set the `log_only` flag in the module options.