### PR TITLE
More principled header forwarding in HTTP filter & v0.5.0

### DIFF
--- a/lib/filters/http.js
+++ b/lib/filters/http.js
@@ -26,10 +26,6 @@ module.exports = function(hyper, req, next, options) {
 
     // Enforce the usage of UA
     req.headers = req.headers || {};
-    req.headers['user-agent'] = hyper._rootReq.headers['user-agent']
-        || req.headers['user-agent']
-        || hyper.config.user_agent;
-    hyper.setRequestId(req);
     hyper.log('trace/webrequest', {
         req: req,
         request_id: req.headers['x-request-id']
@@ -37,11 +33,47 @@ module.exports = function(hyper, req, next, options) {
     // Make sure we have a string
     req.uri = '' + req.uri;
 
-    if (match.matcher.forward_headers) {
-        if (hyper.ctx.headers) {
-            req.headers = req.headers || {};
+
+    // The request ID is not personally identifyable information without
+    // access to logstash, so always set / forward it.
+    hyper.setRequestId(req);
+
+    var forwardHeaders = match.matcher.forward_headers;
+
+    // General precedence:
+    // 1) req.headers
+    // 2) hyper.ctx.headers (default: user-agent, x-forwarded-for &
+    //    x-client-ip)
+    function forwardHeader(name, defaultVal) {
+        if (forwardHeaders === true || forwardHeaders[name]) {
+            var newVal = req.headers[name] || defaultVal;
+            if (newVal === undefined) {
+                newVal = hyper.ctx.headers[name];
+            }
+            if (newVal === undefined && name === 'user-agent') {
+                newVal = hyper.config.user_agent;
+            }
+
+            if (newVal) {
+                req.headers[name] = newVal;
+            }
+        }
+    }
+
+    if (forwardHeaders) {
+        // All headers but the random request ID are potentially personally
+        // identifyable information, so only forward it to explicitly trusted
+        // services.
+
+        if (forwardHeaders === true) {
             Object.keys(hyper.ctx.headers).forEach(function(headerName) {
-                req.headers[headerName] = req.headers[headerName] || hyper.ctx.headers[headerName];
+                forwardHeader(headerName);
+            });
+        } else {
+            // forwardHeaders is an object indicating which headers to
+            // forward.
+            Object.keys(forwardHeaders).forEach(function(headerName) {
+                forwardHeader(headerName);
             });
         }
     }

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -54,7 +54,12 @@ function HyperSwitch(options, req, parOptions) {
         this._rootReq.headers = this._rootReq.headers || {};
         this._requestFilters = par._requestFilters;
         this._subRequestFilters = par._subRequestFilters;
-        this.ctx = par.ctx || {};
+        this.ctx = par.ctx || {
+            headers: {
+                'user-agent': req.headers['user-agent'],
+                'x-client-ip': req.headers['x-client-ip'],
+            }
+        };
     } else {
         // Brand new instance
         this.log = options.log; // Logging method

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.4.10",
+  "version": "0.5.0",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/hyperswitch/test_config.yaml
+++ b/test/hyperswitch/test_config.yaml
@@ -3,6 +3,14 @@ spec_root: &spec_root
   x-sub-request-filters:
     - type: default
       name: http
+      options:
+        allow:
+          - pattern: /^https?:\/\/en.wikipedia.org\//
+            forward_headers:
+              user-agent: true
+          - pattern: /^https?:\/\/trusted.service\//
+            forward_headers: true
+          - pattern: /^https?:\/\//
   # Some more general RESTBase info
   paths:
     /service/recursive/{title}:
@@ -72,12 +80,12 @@ spec_root: &spec_root
                   result: '{$.request.body.field}'
         x-monitor: false
 
-    /service/hop_to_hop:
+    /service/hop_to_hop/{domain}:
       get:
         x-request-handler:
           - backend:
               request:
-                uri: https://en.wikipedia.org/wiki/Main_Page
+                uri: https://{domain}/wiki/Main_Page
 
     /service/module:
       x-modules:


### PR DESCRIPTION
- Add x-client-ip to the default headers forwarded to trusted services.
- Only forward personally identifyable information if forward_headers is
  truish, and only ever forward from the request, or hyper.ctx.
- Support explicit header whitelisting per backend service, by configuring an
  object indicating allowed headers.
- Improved testing for header filtering.
- Release v0.5.0