### PR TITLE
Added x-triggered-by to the list of logged headers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -334,6 +334,7 @@ function handleRequest(opts, req, resp) {
                 'x-forwarded-for': req.headers['x-forwarded-for'],
                 'x-request-id': req.headers['x-request-id'],
                 'x-request-class': req.headers['x-request-class'],
+                'x-triggered-by': req.headers['x-triggered-by']
             },
         },
         request_id: req.headers['x-request-id']


### PR DESCRIPTION
We need to log this headers for debugging purposes

cc @wikimedia/services 