### PR TITLE
cloneRequest strips preq properties

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -22,6 +22,7 @@ var swaggerUI = require('./swaggerUI');
  */
 function cloneRequest(req) {
     var newReq = Object.assign({}, req);
+    newReq.url = undefined;
     newReq.uri = req.uri || req.url || null;
     newReq.method = req.method || 'get';
     newReq.headers = req.headers || {};

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -21,14 +21,14 @@ var swaggerUI = require('./swaggerUI');
  * @returns a shallow copy of a provided requests
  */
 function cloneRequest(req) {
-    return {
-        uri: req.uri || req.url || null,
-        method: req.method || 'get',
-        headers: req.headers || {},
-        query: req.query || {},
-        body: req.body !== undefined ? req.body : null,
-        params: req.params || {}
-    };
+    var newReq = Object.assign({}, req);
+    newReq.uri = req.uri || req.url || null;
+    newReq.method = req.method || 'get';
+    newReq.headers = req.headers || {};
+    newReq.query = req.query || {};
+    newReq.body = req.body !== undefined ? req.body : null;
+    newReq.params = req.params || {};
+    return newReq;
 }
 
 function HyperSwitch(options, req, parOptions) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In change-propagation we explicitly set `followRedirect` and `retry` properties for the request, but hyper's `cloneRequest` method strip them out again.

cc @wikimedia/services 