### PR TITLE
Always log rate limit violations

### DIFF
--- a/lib/filters/ratelimit_route.js
+++ b/lib/filters/ratelimit_route.js
@@ -21,13 +21,12 @@ module.exports = function(hyper, req, next, options, specInfo) {
 
     var key = pathKey + '|' + hyper._rootReq.headers['x-client-ip'];
     if (hyper.ratelimiter.isAboveLimit(key, options.limits[requestClass])) {
-        if (options.log_only) {
-            hyper.log('warn/ratelimit/' + pathKey, {
-                key: key,
-                rate_limit_per_second: options.limits[requestClass],
-                message: 'Rate limit exceeded'
-            });
-        } else {
+        hyper.log('warn/ratelimit/' + pathKey, {
+            key: key,
+            rate_limit_per_second: options.limits[requestClass],
+            message: 'Rate limit exceeded'
+        });
+        if (!options.log_only) {
             throw new HTTPError({
                 status: 429,
                 body: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We don't generally log 4xx responses, so don't have a good record of
rate-limited requests. For now, request volumes are not a major concern, so
this patch changes the behavior to always log all rate limit violations. If
logging volume becomes a concern in the future, we can add (auto-) sampling.

Task: https://phabricator.wikimedia.org/T136769