### PR TITLE
Make sure that default route filters are processed first

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -578,11 +578,15 @@ Router.prototype.loadSpec = function(spec, hyper) {
         }
     });
 
-    // First load default request filters
+    // First load default request filters. The order of the stack matters.
     // TODO: Do that in a cleaner way
-    spec['x-route-filters'] = spec['x-route-filters'] || [];
-    spec['x-route-filters'].push({ type: 'default', name: 'validator' });
-    spec['x-route-filters'].push({ type: 'default', name: 'metrics' });
+    spec['x-route-filters'] = [{
+            type: 'default', name: 'metrics'
+        },
+        {
+            type: 'default', name: 'validator'
+        }
+    ].concat(spec['x-route-filters'] || []);
     return self._handleSwaggerSpec(rootNode, spec, scope)
     .then(function() {
         (spec['x-request-filters'] || []).forEach(function(filterDef) {


### PR DESCRIPTION
We generally want to record metrics for all requests, even those that are
rejected by other filters. For this reason, it is important that the metrics
filter is installed highest in the stack.

This patch generally changes the initialization so that default filters are
placed highest in the stack, followed by custom filters from the spec.