### PR TITLE
Export lifecycle EventEmitter

### DIFF
--- a/lib/exports.js
+++ b/lib/exports.js
@@ -4,8 +4,44 @@ var util = require('util');
 var swaggerRouter = require('swagger-router');
 var yaml = require('js-yaml');
 var fs = require('fs');
+var EventEmitter = require('events').EventEmitter;
 
 var exports = {};
+
+function Lifecycle() {
+    EventEmitter.call(this);
+    this._initialized = false;
+}
+util.inherits(Lifecycle, EventEmitter);
+
+/**
+ * Lazily sets up forwarding of the application-lifecycle events
+ * to the exported object. Only called if the client subscribed to
+ * some events.
+ *
+ * @private
+ */
+Lifecycle.prototype._setup = function() {
+    var self = this;
+    // The server will certainly be initialized by now
+    var server = require('./server').server;
+    server.on('close', function() { self.emit('close'); });
+};
+[
+    'addListener',
+    'on',
+    'once',
+    'prependListener',
+    'prependOnceListener'
+].forEach(function(funcName) {
+    Lifecycle.prototype[funcName] = function(eventName, listener) {
+        if (!this._initialized) {
+            this._setup();
+        }
+        EventEmitter.prototype[funcName].call(this, eventName, listener);
+    };
+});
+exports.lifecycle = new Lifecycle();
 
 /*
  * Error instance wrapping HTTP error responses

--- a/lib/server.js
+++ b/lib/server.js
@@ -430,6 +430,9 @@ function main(options) {
         }
     };
 
+    main.server = http.createServer(handleRequest.bind(null, opts));
+    main.server.maxConnections = 500;
+
     opts.router = new Router(opts);
     opts.hyper = new HyperSwitch(opts);
     // Use a child HyperSwitch instance to sidestep the security protection for
@@ -441,17 +444,15 @@ function main(options) {
     // Main app startup happens during async spec loading:
     return opts.router.loadSpec(conf.spec, childHyperSwitch)
     .then(function() {
-        var server = http.createServer(handleRequest.bind(null, opts));
         // Use a large listen queue
         // Also, echo 1024 | sudo tee /proc/sys/net/core/somaxconn
         // (from 128 default)
         var port = conf.port || 7231;
         var host = conf.host;
         // Apply some back-pressure.
-        server.maxConnections = 500;
-        server.listen(port, host);
+        main.server.listen(port, host);
         opts.log('warn/startup', 'listening on ' + (host || '*') + ':' + port);
-        return server;
+        return main.server;
     })
     .catch(function(e) {
         opts.log('fatal/startup', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Sometimes we might need to perform some cleanup actions in the app when the server is closed (an example is https://github.com/wikimedia/change-propagation/pull/50), so export a `lifecycle` EventEmitter from HyperSwitch. Event forwarding is setup lazily so that we don't waist resources if it's not needed, and the only event we forward now is `close`, but the set of events could easily be expanded.