### PR TITLE
Don't try to parse JSON body if it's an empty string

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -364,10 +364,12 @@ function handleRequest(opts, req, resp) {
     .then(function(body) {
 
         if (body && /^application\/json/i.test(req.headers['content-type'])) {
-            try {
-                body = JSON.parse(body.toString());
-            } catch (e) {
-                reqOpts.log('error/request/json-parsing', e);
+            if (body.toString()) {
+                try {
+                    body = JSON.parse(body.toString());
+                } catch (e) {
+                    reqOpts.log('error/request/json-parsing', e);
+                }
             }
         }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -364,9 +364,10 @@ function handleRequest(opts, req, resp) {
     .then(function(body) {
 
         if (body && /^application\/json/i.test(req.headers['content-type'])) {
-            if (body.toString()) {
+            var bodyStr = body.toString();
+            if (bodyStr) {
                 try {
-                    body = JSON.parse(body.toString());
+                    body = JSON.parse(bodyStr);
                 } catch (e) {
                     reqOpts.log('error/request/json-parsing', e);
                 }

--- a/test/hyperswitch/hyperswitch.js
+++ b/test/hyperswitch/hyperswitch.js
@@ -134,6 +134,19 @@ describe('HyperSwitch context', function() {
         });
     });
 
+    it('is OK with empty POST', function() {
+        return preq.post({
+            uri: server.hostPort + '/service/empty_body',
+            headers: {
+                'content-type': 'application/json'
+            }
+        })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body, {result: 'value'});
+        });
+    });
+
     var simpleSpec = {
         paths: {
             '/test': {

--- a/test/hyperswitch/test_config.yaml
+++ b/test/hyperswitch/test_config.yaml
@@ -80,6 +80,18 @@ spec_root: &spec_root
                   result: '{$.request.body.field}'
         x-monitor: false
 
+    /service/empty_body:
+      post:
+        x-request-handler:
+          - get_from_api:
+              return:
+                status: 200
+                headers:
+                  content-type: 'application/json'
+                body:
+                  result: 'value'
+        x-monitor: false
+
     /service/hop_to_hop/{domain}:
       get:
         x-request-handler:


### PR DESCRIPTION
Parsing a body could return a `Buffer` that has no content in it, so `!!body === true`, but JSON parsing is still failing.

cc @wikimedia/services 