### PR TITLE
Don't log complete internalReq.body on error

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -340,8 +340,13 @@ HyperSwitch.prototype._request = function(req, options) {
             } else if (!(res.status >= 100 && res.status < 400) && !(res instanceof Error)) {
                 var err = new HTTPError(res);
                 if (res.body && res.body.stack) { err.stack = res.body.stack; }
-                err.innerBody = res.body;
-                err.internalReq = req;
+                err.innerBody = res.body && JSON.stringify(res.body).substr(0, 200);
+                err.internalReq = req && {
+                        method: req.method,
+                        headers: req.headers,
+                        query: req.query,
+                        body: req.body && JSON.stringify(req.body).substr(0, 200)
+                    };
                 throw err;
             } else {
                 return res;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The body of the `internalReq` property might contain a JSON with random keys or a huge blob of HTML/Wikitext. This creates problems in logstash, so we need to limit the log a bit.

Bug: https://phabricator.wikimedia.org/T141384

cc @wikimedia/services 