### PR TITLE
Doc handling improvements

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -113,7 +113,10 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
     var rq = req.query;
     if (rq.spec !== undefined
             && match.value.specRoot && !match.value.specRoot['x-listing']) {
-        var spec = Object.assign({}, match.value.specRoot);
+        var spec = Object.assign({}, match.value.specRoot, {
+            // Set the base path dynamically
+            basePath: req.uri.toString().replace(/\/$/, '')
+        });
 
         if (req.params.domain === req.headers.host.replace(/:[0-9]+$/, '')) {
             // This is a host-based request. Set an appropriate base path.

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -107,31 +107,43 @@ HyperSwitch.prototype.makeChild = function(req, options) {
     return new HyperSwitch(this, req, options);
 };
 
+function getDocBasePath(req, spec) {
+    if (req.params.domain === req.headers.host.replace(/:[0-9]+$/, '')
+            && spec['x-host-basePath']) {
+        // This is a host-based request. Set an appropriate base path.
+        return spec['x-host-basePath'];
+    }
+    return req.uri.toString().replace(/\/$/, '');
+}
 // A default listing handler for URIs that end in / and don't have any
 // handlers associated with it otherwise.
 HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
     var rq = req.query;
     if (rq.spec !== undefined
             && match.value.specRoot && !match.value.specRoot['x-listing']) {
-        var spec = Object.assign({}, match.value.specRoot, {
-            // Set the base path dynamically
-            basePath: req.uri.toString().replace(/\/$/, '')
-        });
-
-        if (req.params.domain === req.headers.host.replace(/:[0-9]+$/, '')) {
-            // This is a host-based request. Set an appropriate base path.
-            spec.basePath = spec['x-host-basePath'] || spec.basePath;
-        }
-
         return P.resolve({
             status: 200,
-            body: spec
+            body: Object.assign({}, match.value.specRoot, {
+                // Set the base path dynamically
+                basePath: getDocBasePath(req, match.value.specRoot)
+            })
         });
     } else if (rq.path ||
         (match.value.specRoot
             && !match.value.specRoot['x-listing']
             && match.value.specRoot.basePath === req.uri.toString().replace(/\/$/, '')
             && /\btext\/html\b/.test(req.headers.accept))) {
+        // If there's ane query parameters except ?path - redirect to the basePath
+        if (Object.keys(req.query).filter(function(paramName) {
+                return paramName !== 'path';
+            }).length) {
+            return {
+                status: 301,
+                headers: {
+                    location: getDocBasePath(req, match.value.specRoot) + '/'
+                }
+            };
+        }
         // Return swagger UI & load spec from /?spec
         if (!req.query.path) {
             req.query.path = '/index.html';

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -113,10 +113,7 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
     var rq = req.query;
     if (rq.spec !== undefined
             && match.value.specRoot && !match.value.specRoot['x-listing']) {
-        var spec = Object.assign({}, match.value.specRoot, {
-            // Set the base path dynamically
-            basePath: req.uri.toString().replace(/\/$/, '')
-        });
+        var spec = Object.assign({}, match.value.specRoot);
 
         if (req.params.domain === req.headers.host.replace(/:[0-9]+$/, '')) {
             // This is a host-based request. Set an appropriate base path.
@@ -127,8 +124,11 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
             status: 200,
             body: spec
         });
-    } else if (rq.doc !== undefined
-            && (match.value.specRoot && !match.value.specRoot['x-listing'] || rq.path)) {
+    } else if (rq.path ||
+        (match.value.specRoot
+            && !match.value.specRoot['x-listing']
+            && match.value.specRoot.basePath === req.uri.toString().replace(/\/$/, '')
+            && /\btext\/html\b/.test(req.headers.accept))) {
         // Return swagger UI & load spec from /?spec
         if (!req.query.path) {
             req.query.path = '/index.html';
@@ -149,7 +149,7 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
                         })
                         .map(function(api) {
                         return '<li><a href="' + encodeURIComponent(api)
-                            + '/?doc">' + api + '</a></li>';
+                            + '/">' + api + '</a></li>';
                     }).join('\n')
                     + '</ul>';
         html += "<h3>JSON listing</h3><p>To retrieve a regular JSON listing, you can either "

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -40,7 +40,7 @@ function staticServe(hyper, req) {
         if (/\.js$/.test(reqPath)) {
             contentType = 'text/javascript';
             body = body.toString()
-                .replace(/underscore\-min\.map/, '?doc=&path=lib/underscore-min.map');
+                .replace(/underscore\-min\.map/, '?path=lib/underscore-min.map');
         } else if (/\.png$/.test(reqPath)) {
             contentType = 'image/png';
         } else if (/\.map$/.test(reqPath)) {
@@ -49,7 +49,7 @@ function staticServe(hyper, req) {
             contentType = 'application/x-font-ttf';
         } else if (/\.css$/.test(reqPath)) {
             contentType = 'text/css';
-            body = body.toString().replace(/\.\.\/(images|fonts)\//g, '?doc&path=$1/');
+            body = body.toString().replace(/\.\.\/(images|fonts)\//g, '?path=$1/');
         }
         return P.resolve({
             status: 200,

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -23,7 +23,7 @@ function staticServe(hyper, req) {
         if (reqPath === '/index.html') {
             // Rewrite the HTML to use a query string
             body = body.toString()
-                .replace(/((?:src|href)=['"])/g, '$1?doc=&path=')
+                .replace(/((?:src|href)=['"])/g, '$1?path=')
                 // Some self-promotion
                 .replace(/<a id="logo".*?<\/a>/,
                         '<a id="logo" href="https://www.mediawiki.org/wiki/RESTBase">RESTBase</a>')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/hyperswitch/docs.js
+++ b/test/hyperswitch/docs.js
@@ -49,7 +49,12 @@ describe('Documentation handling', function() {
     });
 
     it('should retrieve all dependencies of the swagger-ui main page', function() {
-        return preq.get({ uri: server.hostPort + '/v1/' })
+        return preq.get({
+            uri: server.hostPort + '/v1/',
+            headers: {
+                accept: 'text/html'
+            }
+        })
         .then(function(res) {
             var assertions = [];
             var linkRegex = /<link\s[^>]*href=["']([^"']+)["']/g;

--- a/test/hyperswitch/docs.js
+++ b/test/hyperswitch/docs.js
@@ -36,20 +36,20 @@ describe('Documentation handling', function() {
 
     it('should retrieve the swagger-ui main page', function() {
         return preq.get({
-            uri: server.hostPort + '/v1/?doc'
+            uri: server.hostPort + '/v1/',
+            headers: {
+                accept: 'text/html'
+            }
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'text/html');
             assert.deepEqual(/<html/.exec(res.body)[0], '<html');
-        })
-            .catch(function (e) {
-                console.log(e);
-            });
+        });
     });
 
     it('should retrieve all dependencies of the swagger-ui main page', function() {
-        return preq.get({ uri: server.hostPort + '/v1/?doc' })
+        return preq.get({ uri: server.hostPort + '/v1/' })
         .then(function(res) {
             var assertions = [];
             var linkRegex = /<link\s[^>]*href=["']([^"']+)["']/g;
@@ -86,7 +86,7 @@ describe('Documentation handling', function() {
 
     it('should throw error for static serve', function() {
         return preq.get({
-            uri: server.hostPort + '/v1/?doc=&path=/this_is_no_a_path',
+            uri: server.hostPort + '/v1/?path=/this_is_no_a_path',
             headers: {
                 accept: 'text/html'
             }
@@ -100,7 +100,7 @@ describe('Documentation handling', function() {
 
     it('should disallow unsecure relative paths for static serve', function() {
         return preq.get({
-            uri: server.hostPort + '/v1/?doc=&path=../../../Test',
+            uri: server.hostPort + '/v1/?path=../../../Test',
             headers: {
                 accept: 'text/html'
             }
@@ -126,7 +126,7 @@ describe('Documentation handling', function() {
 
     it('should not allow doc requests to sys', function () {
         return preq.get({
-            uri: server.hostPort + '/sys/?doc=',
+            uri: server.hostPort + '/sys/',
             headers: {
                 accept: 'text/html'
             }


### PR DESCRIPTION
We need some improvements for docs handling. After this patch, here's how the docs would work:
In the browser:
 - https://en.wikipedia.org/api/rest_v1/ would show main swagger page
 - https://en.wikipedia.org/api/rest_v1/page/ would give a listing of page-related endpoints in JSON
 - https://en.wikipedia.org/api/rest_v1/?doc will 301 redirect to https://en.wikipedia.org/api/rest_v1/ 
In curl:
 - https://en.wikipedia.org/api/rest_v1/ would give a listing in JSON

As you can see, we don't need the confusing ?doc parameter any more since now it varies on the `accept` header. 

Bug: https://phabricator.wikimedia.org/T141402
cc @wikimedia/services 