### PR TITLE
Make docs name and URI configurable

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -418,8 +418,9 @@ function handleRequest(opts, req, resp) {
 function main(options) {
     var conf = options.config || {};
     // Set up the global options object with a logger
-    conf.service_name = options.name;
-    conf.docs_name = conf.docs_name || options.name[0].toUpperCase() + options.name.substr(1);
+    conf.service_name = options.name || 'HyperSwitch Service';
+    conf.docs_name = conf.docs_name
+        || conf.service_name[0].toUpperCase() + conf.service_name.substr(1);
     var opts = {
         appBasePath: options.appBasePath,
         conf: conf,

--- a/lib/server.js
+++ b/lib/server.js
@@ -419,6 +419,7 @@ function main(options) {
     var conf = options.config || {};
     // Set up the global options object with a logger
     conf.service_name = options.name;
+    conf.docs_name = conf.docs_name || options.name[0].toUpperCase() + options.name.substr(1);
     var opts = {
         appBasePath: options.appBasePath,
         conf: conf,

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -24,16 +24,17 @@ function staticServe(hyper, req) {
             // Rewrite the HTML to use a query string
             body = body.toString()
                 .replace(/((?:src|href)=['"])/g, '$1?doc=&path=')
-                // Some self-promotion
-                .replace(/<a id="logo".*?<\/a>/,
-                        '<a id="logo" href="https://www.mediawiki.org/wiki/RESTBase">RESTBase</a>')
-                .replace(/<title>[^<]*<\/title>/,
-                        '<title>RESTBase docs</title>') // TODO: Make this configurable
                 // Replace the default url with ours, switch off validation &
                 // limit the size of documents to apply syntax highlighting to
                 .replace(/Sorter: "alpha"/, 'Sorter: "alpha", ' + 'validatorUrl: null, ' +
                     'highlightSizeThreshold: 10000, docExpansion: "list"')
-                .replace(/ url: url,/, 'url: "?spec",');
+                .replace(/ url: url,/, 'url: "?spec",')
+            // Some self-promotion
+                .replace(/<title>[^<]*<\/title>/,
+                    '<title>' + hyper.config.docs_name + '</title>')
+                .replace(/<a id="logo".*?<\/a>/,
+                    '<a id="logo" href="' + (hyper.config.docs_uri || req.uri.toString()) + '">'
+                        + hyper.config.docs_name + '</a>');
         }
 
         var contentType = 'text/html';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We need the config change for RB for that to get back to proper name and URI

Bug: https://phabricator.wikimedia.org/T125412
cc @wikimedia/services 
