### PR TITLE
Expand docs by default

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -32,7 +32,8 @@ function staticServe(hyper, req) {
                 // Replace the default url with ours, switch off validation &
                 // limit the size of documents to apply syntax highlighting to
                 .replace(/Sorter: "alpha"/, 'Sorter: "alpha", ' + 'validatorUrl: null, ' +
-                    'highlightSizeThreshold: 10000, docExpansion: "list"')
+                    'highlightSizeThreshold: 10000')
+                .replace(/docExpansion: "none"/, 'docExpansion: "list"')
                 .replace(/ url: url,/, 'url: "?spec",');
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
After the upgrade to `swagger-ui` it doesn't show docs expanded by default any more. Fix it back to how it used to be.

cc @wikimedia/services 