### PR TITLE
Fix specRoot / basePath handling

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -131,7 +131,7 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
     } else if (rq.path ||
         (match.value.specRoot
             && !match.value.specRoot['x-listing']
-            && match.value.specRoot.basePath === req.uri.toString().replace(/\/$/, '')
+            && match.value.specRoot
             && /\btext\/html\b/.test(req.headers.accept))) {
         // If there's ane query parameters except ?path - redirect to the basePath
         if (Object.keys(req.query).filter(function(paramName) {
@@ -150,7 +150,7 @@ HyperSwitch.prototype.defaultListingHandler = function(match, hyper, req) {
         }
         return swaggerUI(hyper, req);
     } else if (/\btext\/html\b/.test(req.headers.accept)
-            && (!match.value.specRoot || match.value.specRoot['x-listing'])) {
+            && match.value.specRoot && match.value.specRoot['x-listing']) {
         // Browser request and above api level
         req.query.path = '/index.html';
         var html = '<div id="swagger-ui-container" class="swagger-ui-wrap">'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/hyperswitch/docs.js
+++ b/test/hyperswitch/docs.js
@@ -48,6 +48,19 @@ describe('Documentation handling', function() {
         });
     });
 
+    it('should not retrieve the swagger-ui main page further down the hierarchy', function() {
+        return preq.get({
+            uri: server.hostPort + '/v1/test/',
+            headers: {
+                accept: 'text/html'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, 'application/json');
+        });
+    });
+
     it('should retrieve all dependencies of the swagger-ui main page', function() {
         return preq.get({
             uri: server.hostPort + '/v1/',

--- a/test/hyperswitch/docs_config.yaml
+++ b/test/hyperswitch/docs_config.yaml
@@ -12,6 +12,13 @@ spec_root: &spec_root
                         return:
                           status: 200
                           body: 'test'
+              /test/test2:
+                get:
+                  x-request-handler:
+                    - return_result:
+                        return:
+                          status: 200
+                          body: 'test2'
     /{api:sys}/test/:
       x-modules:
         - type: inline


### PR DESCRIPTION
Don't rely on specRoot.basePath to match the current domain, and instead just
check for the presence of specRoot. As we now configure specRoot at the root
of the hierarchy as well, we do not need the exception for the domain listing
at `/` any more.

Task: https://phabricator.wikimedia.org/T142366