### PR TITLE
Sort paths before building the tree

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -421,8 +421,9 @@ Router.prototype._handlePaths = function(rootNode, spec, scope) {
 
     // Handle paths
     // Sequence the build process with `.each` to avoid race conditions
-    // while building the tree.
-    return P.each(Object.keys(paths), function(pathPattern) {
+    // while building the tree. Also sort(), so that fixed path segments sort
+    // before patterns (by virtue of `[a-zA-Z/] < '{'`).
+    return P.each(Object.keys(paths).sort(), function(pathPattern) {
         var pathSpec = paths[pathPattern];
         var pathURI = new URI(pathPattern, {}, true);
         var path = pathURI.path;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Deterministically resolve conflicts & add specific keys before wildcards.

Without this patch, a path combination like

  /{something}/else
  /robots.txt

was not accepted, as v8 happens to preserve the order of object keys in this
case, and the wildcard would be added before the fixed value. This would cause
the router to enter the wildcard path when trying to add robots.txt.

With this patch, more specific paths (without wildcards) are built first,
equivalent to:

  /robots.txt
  /{something}/else