### PR TITLE
For discussion: Support spec-level x-modules, and fix modules at API level

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -421,8 +421,9 @@ Router.prototype._handlePaths = function(rootNode, spec, scope) {
 
     // Handle paths
     // Sequence the build process with `.each` to avoid race conditions
-    // while building the tree.
-    return P.each(Object.keys(paths), function(pathPattern) {
+    // while building the tree. Also sort(), so that fixed path segments sort
+    // before patterns (by virtue of `[a-zA-Z/] < '{'`).
+    return P.each(Object.keys(paths).sort(), function(pathPattern) {
         var pathSpec = paths[pathPattern];
         var pathURI = new URI(pathPattern, {}, true);
         var path = pathURI.path;

--- a/lib/router.js
+++ b/lib/router.js
@@ -340,6 +340,7 @@ Router.prototype._registerMethods = function(node, pathspec, scope) {
             }
         }
 
+
         if (reqHandler) {
             node.value.methods[methodName] = reqHandler;
             node.value.methods[methodName].spec = method;
@@ -349,11 +350,12 @@ Router.prototype._registerMethods = function(node, pathspec, scope) {
 
 Router.prototype._createNewApiRoot = function(node, spec, scope) {
     var specRoot = Object.assign({}, spec);
-    specRoot.swagger = specRoot.swagger || '2.0';
-    specRoot.paths = {};
-    specRoot.definitions = {};
-    specRoot.securityDefinitions = {};
-    specRoot['x-default-params'] = {};
+    // Make sure the spec has the standard properties set up.
+    specRoot.swagger = spec.swagger || '2.0';
+    specRoot.paths = spec.paths || {};
+    specRoot.definitions = spec.definitions || {};
+    specRoot.securityDefinitions = spec.securityDefinitions || {};
+    specRoot['x-default-params'] = spec['x-default-params'] || {};
     specRoot.basePath = scope.prefixPath;
 
     node.setChild('', new Node({
@@ -365,7 +367,6 @@ Router.prototype._createNewApiRoot = function(node, spec, scope) {
 
     return scope.makeChild({
         specRoot: specRoot,
-        operations: {},
         prefixPath: ''
     });
 };
@@ -439,7 +440,7 @@ Router.prototype._handlePaths = function(rootNode, spec, scope) {
             path: undefined,
             methods: {},
             resources: [],
-            globals: childScope.globals || {},
+            globals: scope.globals || {},
         };
 
         // Expected to return
@@ -475,12 +476,13 @@ Router.prototype._handlePaths = function(rootNode, spec, scope) {
                     branchNode.value = value;
                 }
 
+                // Path spec with only x-modules & no methods: Forward globals
+                // & set up caching.
                 if (Object.keys(pathSpec).length === 1 && pathSpec['x-modules']) {
                     subtree._parentGlobals = childScope.globals;
                     self._nodes.set(pathSpec, subtree);
                 }
             }
-
 
             // Handle the path spec
             specPromise = self._handleSwaggerPathSpec(subtree, pathSpec, childScope, segment);
@@ -507,17 +509,13 @@ Router.prototype._handlePaths = function(rootNode, spec, scope) {
  * @return {Promise<void>}
  */
 Router.prototype._handleSwaggerSpec = function(node, spec, scope, parentSegment) {
-    if (parentSegment && parentSegment.name === 'api') {
-        // Client is using multi-api feature, mark root spec as listing spec
-        scope.rootScope.specRoot['x-listing'] = true;
-    }
+    var self = this;
 
     if (!parentSegment || parentSegment.name === 'api') {
         var listingNode = node.getChild('');
         if (listingNode) {
             scope = scope.makeChild({
                 specRoot: listingNode.value.specRoot,
-                operations: {},
                 prefixPath: '',
             });
         } else {
@@ -526,12 +524,25 @@ Router.prototype._handleSwaggerSpec = function(node, spec, scope, parentSegment)
         }
         scope.rootScope = scope;
     }
-    Object.assign(scope.specRoot.definitions, spec.definitions || {});
-    Object.assign(scope.specRoot.securityDefinitions, spec.securityDefinitions || {});
+
+    // Merge in definitions & securityDefinitions from the spec.
+    // TODO: Do we need a clone here? Is it okay if those definitions are
+    // added to the higher level spec?
+    Object.assign(scope.specRoot.definitions, spec.definitions);
+    Object.assign(scope.specRoot.securityDefinitions, spec.securityDefinitions);
 
     this._loadRouteFilters(node, spec, scope);
 
-    return this._handlePaths(node, spec, scope);
+    var loadPromise = self._handlePaths(node, spec, scope);
+    // Also support spec-level modules.
+    var xModules = spec['x-modules'];
+    if (xModules) {
+        loadPromise = loadPromise
+            .then(function() {
+                return self._loadModules(node, xModules, scope, parentSegment);
+            });
+    }
+    return loadPromise;
 };
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -422,9 +422,8 @@ Router.prototype._handlePaths = function(rootNode, spec, scope) {
 
     // Handle paths
     // Sequence the build process with `.each` to avoid race conditions
-    // while building the tree. Also sort(), so that fixed path segments sort
-    // before patterns (by virtue of `[a-zA-Z/] < '{'`).
-    return P.each(Object.keys(paths).sort(), function(pathPattern) {
+    // while building the tree.
+    return P.each(Object.keys(paths), function(pathPattern) {
         var pathSpec = paths[pathPattern];
         var pathURI = new URI(pathPattern, {}, true);
         var path = pathURI.path;
@@ -473,6 +472,9 @@ Router.prototype._handlePaths = function(rootNode, spec, scope) {
                 } else if (segment.modifier === '/') {
                     // Since this path segment is optional, the parent node
                     // has the same value.
+                    // FIXME: Properly handle the case where paths overlap, as
+                    // in /foo and /foo{/bar}, possibly by merging methods
+                    // after initializing them with _handleSwaggerPathSpec().
                     branchNode.value = value;
                 }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -340,7 +340,6 @@ Router.prototype._registerMethods = function(node, pathspec, scope) {
             }
         }
 
-
         if (reqHandler) {
             node.value.methods[methodName] = reqHandler;
             node.value.methods[methodName].spec = method;

--- a/lib/router.js
+++ b/lib/router.js
@@ -283,22 +283,22 @@ Router.prototype._loadModules = function(node, hyperModules, scope, parentSegmen
  */
 Router.prototype._registerMethods = function(node, pathspec, scope) {
     var self = this;
-    // Register the path in the specRoot
-    if (scope.specRoot && !scope.specRoot.paths[scope.prefixPath]
-            // But don't load empty paths.
-            && scope.prefixPath) {
-        scope.specRoot.paths[scope.prefixPath] = {};
-    }
 
     Object.keys(pathspec).forEach(function(methodName) {
         if (/^x-/.test(methodName)) {
             return;
         }
         var method = pathspec[methodName];
+        var specPaths = scope.specRoot.paths;
         // Insert the method spec into the global merged spec
-        if (scope.specRoot.paths[scope.prefixPath] && methodName
-                && !scope.specRoot.paths[scope.prefixPath][methodName]) {
-            scope.specRoot.paths[scope.prefixPath][methodName] = method;
+        if (method && !method['x-hidden']
+                && (!specPaths[scope.prefixPath]
+                    || !specPaths[scope.prefixPath][methodName])) {
+            // Register the path in the specRoot
+            if (!specPaths[scope.prefixPath]) {
+                specPaths[scope.prefixPath] = {};
+            }
+            specPaths[scope.prefixPath][methodName] = method;
         }
 
         if (node.value.methods.hasOwnProperty(methodName)) {
@@ -352,10 +352,12 @@ Router.prototype._createNewApiRoot = function(node, spec, scope) {
     var specRoot = Object.assign({}, spec);
     // Make sure the spec has the standard properties set up.
     specRoot.swagger = spec.swagger || '2.0';
-    specRoot.paths = spec.paths || {};
     specRoot.definitions = spec.definitions || {};
     specRoot.securityDefinitions = spec.securityDefinitions || {};
     specRoot['x-default-params'] = spec['x-default-params'] || {};
+
+    // Reset paths. These are going to be built up during path setup.
+    specRoot.paths = {};
     specRoot.basePath = scope.prefixPath;
 
     node.setChild('', new Node({

--- a/lib/router.js
+++ b/lib/router.js
@@ -540,10 +540,9 @@ Router.prototype._handleSwaggerSpec = function(node, spec, scope, parentSegment)
     // Also support spec-level modules.
     var xModules = spec['x-modules'];
     if (xModules) {
-        loadPromise = loadPromise
-            .then(function() {
-                return self._loadModules(node, xModules, scope, parentSegment);
-            });
+        loadPromise = loadPromise.then(function() {
+            return self._loadModules(node, xModules, scope, parentSegment);
+        });
     }
     return loadPromise;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Support x-modules at spec level (same level as paths). This allows modules
  to define top-level entry points, like /somepath. The alternative would be
  to support paths: { '': { 'x-modules': {...} } }, but imho that's uglier
  than x-modules at the path level. The swagger spec requires paths to start
  with '/' as well, so this would not be a valid swagger spec.
- Preserve operations & some other scope data for API-level modules.
  Otherwise, modules at API level do not have access to their own operations.