### PR TITLE
Coerce body if it's not application/json request

### DIFF
--- a/lib/filters/validator.js
+++ b/lib/filters/validator.js
@@ -53,14 +53,19 @@ var Validator = function(parameters) {
         throw new Error('Only a single body parameter allowed');
     } else if (bodyParams.length) {
         // Have a body parameter, special-case coercion to support formData and JSON
-        this._bodyCoercionFunc = function(req) {
-            if (req && req.body && typeof req.body === 'object') {
-                Object.keys(req.body).forEach(function(bodyKey) {
-                    req.body[bodyKey] = JSON.parse(req.body[bodyKey]);
-                });
-            }
-            return req;
-        };
+        var bodyParam = bodyParams[0];
+        if (bodyParam.schema && bodyParam.schema.properties) {
+            this._bodyCoercionFunc = this._createTypeCoercionFunc(
+                Object.keys(bodyParam.schema.properties).map(function(prop) {
+                    return {
+                        name: prop,
+                        in: 'body',
+                        type: bodyParam.schema.properties[prop].type,
+                        required: bodyParam.schema.required
+                            && bodyParam.schema.required.indexOf(prop) !== -1
+                    };
+                }));
+        }
     } else {
         this._bodyCoercionFunc = this._createTypeCoercionFunc(parameters.filter(function(p) {
             return p.in === 'formData' && p.type !== 'string';
@@ -163,6 +168,13 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
                     + errorNotifier + '}\n'
                     + paramAccessor + ' = /^true|1|yes$/i.test('
                     + paramAccessor + ' + "");\n';
+                break;
+            case 'object':
+                errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
+                    + ' title:"Invalid parameters", detail: "data.'
+                    + inMapping[param.in] + '.' + param.name + ' should be an object."}});\n';
+                paramCoercionCode += 'try{' + paramAccessor + '=JSON.parse(' + paramAccessor + ')'
+                    + '}catch(e){' + errorNotifier + '}';
         }
 
         if (paramCoercionCode) {

--- a/lib/filters/validator.js
+++ b/lib/filters/validator.js
@@ -48,9 +48,24 @@ var Validator = function(parameters) {
     this._paramCoercionFunc = this._createTypeCoercionFunc(parameters.filter(function(p) {
         return p.in !== 'formData' && p.in !== 'body' && p.type !== 'string';
     }));
-    this._bodyCoercionFunc = this._createTypeCoercionFunc(parameters.filter(function(p) {
-        return p.in === 'formData' && p.type !== 'string';
-    }));
+    var bodyParams = parameters.filter(function(p) { return p.in === 'body'; });
+    if (bodyParams.length > 1) {
+        throw new Error('Only a single body parameter allowed');
+    } else if (bodyParams.length) {
+        // Have a body parameter, special-case coercion to support formData and JSON
+        this._bodyCoercionFunc = function(req) {
+            if (req && req.body && typeof req.body === 'object') {
+                Object.keys(req.body).forEach(function(bodyKey) {
+                    req.body[bodyKey] = JSON.parse(req.body[bodyKey]);
+                });
+            }
+            return req;
+        };
+    } else {
+        this._bodyCoercionFunc = this._createTypeCoercionFunc(parameters.filter(function(p) {
+            return p.in === 'formData' && p.type !== 'string';
+        }));
+    }
     this._validatorFunc = this._ajv.compile(this._convertToJsonSchema(parameters));
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/filters/validator.js
+++ b/test/filters/validator.js
@@ -66,6 +66,9 @@ describe('Validator filter', function () {
     it('Should validate object schemas', function () {
         try {
             testValidator({
+                headers: {
+                    'content-type': 'application/json'
+                },
                 body: {
                     field1: 'some string'
                 }
@@ -197,6 +200,9 @@ describe('Validator filter', function () {
 
     it('Should accept body params without a schema and type', function () {
         testValidator({
+            headers: {
+                'content-type': 'application/json'
+            },
             body: {
                 test: 'test'
             }
@@ -215,6 +221,20 @@ describe('Validator filter', function () {
             assert.deepEqual(e.constructor.name, 'HTTPError');
             assert.deepEqual(e.body.detail, "data.body should be object");
         }
+    });
+
+    it('Should coerce body-params for formData', function () {
+        assert.deepEqual(testValidator({
+            body: {
+                test: JSON.stringify({test: "test"})
+            }
+        }, [
+            {name: 'bodyParam', in: 'body', required: true}
+        ], {
+            body: {
+                test: {test: "test"}
+            }
+        }));
     });
 
     it('Should allow non-required body', function () {

--- a/test/filters/validator.js
+++ b/test/filters/validator.js
@@ -6,8 +6,11 @@
 var assert = require('./../utils/assert.js');
 var validator = require('../../lib/filters/validator');
 
-var testValidator = function (req, parameters) {
-    return validator(null, req, function () {
+var testValidator = function (req, parameters, example) {
+    return validator(null, req, function (hyper, req) {
+        if (example) {
+            assert.deepEqual(req, example);
+        }
     }, null, {
         spec: {
             parameters: parameters
@@ -223,18 +226,36 @@ describe('Validator filter', function () {
         }
     });
 
-    it('Should coerce body-params for formData', function () {
-        assert.deepEqual(testValidator({
+    it('Should coerce body-params for formData with schema', function () {
+        testValidator({
             body: {
-                test: JSON.stringify({test: "test"})
+                test: JSON.stringify({test: "test"}),
+                bool: 'true',
+                string: 'string'
             }
         }, [
-            {name: 'bodyParam', in: 'body', required: true}
+            {name: 'bodyParam', in: 'body', required: true, schema: {
+                properties: {
+                    test: {
+                        type: 'object'
+                    },
+                    bool: {
+                        type: 'boolean'
+                    },
+                    string: {
+                        type: 'string'
+                    }
+                }
+            }}
         ], {
             body: {
-                test: {test: "test"}
+                test: {
+                    test: "test"
+                },
+                bool: true,
+                string: 'string'
             }
-        }));
+        });
     });
 
     it('Should allow non-required body', function () {


### PR DESCRIPTION
After we've switched sections endpoint to `application/json` VE can't talk to it any more since VirtualRESTService doesn't support providing application/json. So we are going to 'secretly' support coercing form-data to JSON for now.

cc @wikimedia/services 