### PR TITLE
Swagger UI: Allow the header and title to be configurable; rel v0.7.1

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -83,6 +83,10 @@ function HyperSwitch(options, req, parOptions) {
 
         this.config = options.conf;
         this.config.user_agent = this.config.user_agent || 'HyperSwitch';
+        // TODO for v >= 0.8.0: replace the next three defaults with HyperSwitch values
+        this.config.ui_name = this.config.ui_name || 'RESTBase';
+        this.config.ui_url = this.config.ui_url || 'https://www.mediawiki.org/wiki/RESTBase';
+        this.config.ui_title = this.config.ui_title || 'RESTBase docs';
         this._rootReq = null;
         this._requestFilters = [];
         this._subRequestFilters = [];

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -22,13 +22,13 @@ function staticServe(hyper, req) {
     .then(function(body) {
         if (reqPath === '/index.html') {
             // Rewrite the HTML to use a query string
+            var cfg = hyper.config;
             body = body.toString()
                 .replace(/((?:src|href)=['"])/g, '$1?path=')
                 // Some self-promotion
                 .replace(/<a id="logo".*?<\/a>/,
-                        '<a id="logo" href="https://www.mediawiki.org/wiki/RESTBase">RESTBase</a>')
-                .replace(/<title>[^<]*<\/title>/,
-                        '<title>RESTBase docs</title>') // TODO: Make this configurable
+                        '<a id="logo" href="' + cfg.ui_url + '">' + cfg.ui_name + '</a>')
+                .replace(/<title>[^<]*<\/title>/, '<title>' + cfg.ui_title + '</title>')
                 // Replace the default url with ours, switch off validation &
                 // limit the size of documents to apply syntax highlighting to
                 .replace(/Sorter: "alpha"/, 'Sorter: "alpha", ' + 'validatorUrl: null, ' +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Introduces three new configuration options - `ui_name`, `ui_url` and `ui_title` - which allow users to change the header and title of the returned HTML page. Their default values have been set to RESTBase's for backward compatibility, but we should probably change them in v0.8.0.

Bug: [T125412](https://phabricator.wikimedia.org/T125412)