### PR TITLE
Enable TCP_NODELAY by default; v0.7.2

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -427,6 +427,12 @@ function main(options) {
         // Apply some back-pressure.
         main.server.listen(port, host);
         opts.log('warn/startup', 'listening on ' + (host || '*') + ':' + port);
+        // Don't delay incomplete packets for 40ms (Linux default) on
+        // pipelined HTTP sockets. We write in large chunks or buffers, so
+        // lack of coalescing should not be an issue here.
+        main.server.on("connection", function(socket) {
+            socket.setNoDelay(true);
+        });
         return main.server;
     })
     .catch(function(e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Benchmarks of the serviceworker proxy showed a minimum response latency
of 40ms for streamed responses. This turned out to be caused by Nagle's
algorithm applied to pipelined HTTP connections, when using streamed
responses.

We use zlib streams to compress all textual content, and are also moving
towards supporting streaming more directly in services like the
serviceworker proxy. Varnish is using persistent HTTP connections by
default, so is also hitting this issue.

This patch removes the delay by setting TCP_NODELAY on all http sockets,
at connection creation time. Benchmark results show significantly
improved latency *and* throughput. The latter might be caused by a
reduced concurrency in node, which outweighs the slightly higher
networking cost from sending incomplete packets.