### PR TITLE
Use closure to allow calling next multiple times

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -268,9 +268,10 @@ HyperSwitch.prototype._createFilteredHandler = function(handler, filters, specIn
                 return handlerWrapper(hyper, req);
             }
 
-            return filter.filter(hyper, req, function(hyper, req) {
+            var next = function(hyper, req) {
                 return handlerWrapper(filterIdx, hyper, req);
-            }, filter.options, specInfo);
+            };
+            return filter.filter(hyper, req, next, filter.options, specInfo);
         } else {
             return P.method(handler)(hyper, req);
         }

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -252,8 +252,8 @@ HyperSwitch.prototype._createFilteredHandler = function(handler, filters, specIn
     if (!filters || !filters.length) {
         return handler;
     }
-    var filterIdx = 0;
-    return function handlerWrapper(hyper, req) {
+
+    function handlerWrapper(filterIdx, hyper, req) {
         if (filters && filterIdx < filters.length) {
             var filter = filters[filterIdx];
             filterIdx++;
@@ -263,15 +263,21 @@ HyperSwitch.prototype._createFilteredHandler = function(handler, filters, specIn
             }
 
             if (filter.method
-                    && filter.method !== req.method
-                    && !(filter.method === 'get' && req.method === 'head')) {
+                && filter.method !== req.method
+                && !(filter.method === 'get' && req.method === 'head')) {
                 return handlerWrapper(hyper, req);
             }
 
-            return filter.filter(hyper, req, handlerWrapper, filter.options, specInfo);
+            return filter.filter(hyper, req, function(hyper, req) {
+                return handlerWrapper(filterIdx, hyper, req);
+            }, filter.options, specInfo);
         } else {
             return P.method(handler)(hyper, req);
         }
+    }
+
+    return function(hyper, req) {
+        return handlerWrapper(0, hyper, req);
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In ChangeProp I need to call the `next` several times from one filter. Before that wasn't possible, because filterIndex wasn't preserved, so each next call was treated as if it was called from a subsequent filter. Adding a level of closures allows us to 'fork' the chain of `next` calls.

cc @wikimedia/services 