### PR TITLE
Correctly pass the wrapper closure in all cases

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -258,19 +258,20 @@ HyperSwitch.prototype._createFilteredHandler = function(handler, filters, specIn
             var filter = filters[filterIdx];
             filterIdx++;
 
+            var next = function(hyper, req) {
+                return handlerWrapper(filterIdx, hyper, req);
+            };
+
             if (typeof filter === 'function') {
-                return filter(hyper, req, handlerWrapper, filter.options, specInfo);
+                return filter(hyper, req, next, filter.options, specInfo);
             }
 
             if (filter.method
                 && filter.method !== req.method
                 && !(filter.method === 'get' && req.method === 'head')) {
-                return handlerWrapper(hyper, req);
+                return handlerWrapper(filterIdx, hyper, req);
             }
 
-            var next = function(hyper, req) {
-                return handlerWrapper(filterIdx, hyper, req);
-            };
             return filter.filter(hyper, req, next, filter.options, specInfo);
         } else {
             return P.method(handler)(hyper, req);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We didn't pass the closure with a handler to the filter correctly in all cases.

cc @wikimedia/services 