### PR TITLE
Increase default HTTP socket timeout from 2 to 6 minutes; v0.8.5

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -433,6 +433,14 @@ function main(options) {
         main.server.on("connection", (socket) => {
             socket.setNoDelay(true);
         });
+
+        // Bump up the default socket timeout from 2 minutes to 6 minutes, so
+        // that timeout responses at the HTTP level are actually returned
+        // before the socket is closed. 6 minutes is the default http request
+        // timeout in mainstream browsers, so there is no point in waiting
+        // beyond that in browser-targeted services. Which is all of the ones
+        // we care about, really.
+        main.server.setTimeout(6 * 60 * 1000);
         return main.server;
     })
     .catch((e) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In the investigation of https://phabricator.wikimedia.org/T150247, we
noticed that RESTBase sometimes closed idle connections after two
minutes, before sending any HTTP timeout response. This is clearly
broken behavior, as we a) waste effort by still finishing the request
processing after closing the socket, and b) don't return any proper
response to the client.

To fix this, this patch bumps up the default HTTP client connection
socket timeout from 2 to 6 minutes. This timeout is chosen to
accommodate all reasonable request timeouts in services targeted at
typical web browsers. HTTP timeouts in browsers are 6 minutes by
default, so any sensible HTTP service needs to actively respond in less
time than that, successful or not.