### PR TITLE
Store specs as meta nodes

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -8,6 +8,7 @@ const P = require('bluebird');
 const utils = require('./utils');
 const HTTPError = require('./exports').HTTPError;
 const swaggerUI = require('./swaggerUI');
+const URI = require('swagger-router').URI;
 
 
 /**
@@ -177,7 +178,7 @@ class HyperSwitch {
     // Process one request
     _request(req, options) {
         // Look up the route in the tree.
-        const match = this._priv.router.route(req.uri);
+        let match = this._priv.router.route(req.uri);
         let handler;
         if (match) {
             req.params = match.params;
@@ -191,14 +192,23 @@ class HyperSwitch {
                         || this._rootReq && this._rootReq.method === 'head')) {
                 handler = methods && methods.get;
             }
+        }
 
-            if (!handler
-                    && req.method === 'get'
-                    && req.uri.path[req.uri.path.length - 1] === '') {
-                // A GET for an URL that ends with /: return a default listing
-                if (!match.value) { match.value = {}; }
-                if (!match.value.path) { match.value.path = '_defaultListingHandler'; }
-                handler = (hyper, req) => this.defaultListingHandler(match, hyper, req);
+        if (!handler
+                && req.method === 'get'
+                && req.uri.path[req.uri.path.length - 1] === '') {
+            // A GET for an URL that ends with /: return a default listing
+            const metaPath = req.uri.path.slice(0, -1);
+            metaPath.push({ type: 'meta', name: 'apiRoot' });
+            let metaMatch = this._priv.router.route(new URI(metaPath, {}, true));
+            if (match || metaMatch) {
+                if (!metaMatch) {
+                    metaMatch = { params: match.params };
+                }
+                if (!metaMatch.value) { metaMatch.value = {}; }
+                if (!metaMatch.value.path) { metaMatch.value.path = '_defaultListingHandler'; }
+                match = metaMatch;
+                handler = (hyper, req) => this.defaultListingHandler(metaMatch, hyper, req);
             }
         }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -414,7 +414,6 @@ class Router {
             // - rootNode for single-element path
             // - a subnode for longer paths
             const branchNode = this._buildPath(rootNode, path.slice(0, path.length - 1), value);
-
             // Check if we can share the subtree for the pathspec.
             let subtree = this._nodes.get(pathSpec);
             let specPromise;
@@ -480,7 +479,7 @@ class Router {
      */
     _handleSwaggerSpec(node, spec, scope, parentSegment) {
         if (!parentSegment || parentSegment.name === 'api') {
-            const listingNode = node.getChild('');
+            const listingNode = node.getChild({ type: 'meta', name: 'apiRoot' });
             if (listingNode) {
                 scope = scope.makeChild({
                     specRoot: listingNode.value.specRoot,
@@ -621,7 +620,7 @@ Router.prototype._createNewApiRoot = (node, spec, scope) => {
     specRoot.paths = {};
     specRoot.basePath = scope.prefixPath;
 
-    node.setChild('', new Node({
+    node.setChild({ type: 'meta', name: 'apiRoot' }, new Node({
         specRoot,
         methods: {},
         path: `${specRoot.basePath}/`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "js-yaml": "^3.5.2",
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.8",
-    "swagger-router": "^0.5.1",
+    "swagger-router": "^0.5.5",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "ajv": "^3.7.2",

--- a/test/router/buildTree.js
+++ b/test/router/buildTree.js
@@ -160,7 +160,7 @@ describe('Router', function() {
             }
         }, fakeHyperSwitch)
         .then(function() {
-            var node = router.route('/test/api/');
+            var node = router.route(['test', 'api', { type: 'meta', name: 'apiRoot' }]);
             assert.deepEqual(!!node, true);
             assert.deepEqual(!!node.value, true);
             assert.deepEqual(!!node.value.specRoot, true);
@@ -177,7 +177,7 @@ describe('Router', function() {
         var router = new Router({ appBasePath: __dirname });
         return router.loadSpec(yaml.safeLoad(fs.readFileSync(__dirname + '/root_api_spec.yaml')), fakeHyperSwitch)
         .then(function() {
-            var node = router.route('/');
+            var node = router.route([{ type: 'meta', name: 'apiRoot' }]);
             assert.deepEqual(!!node, true);
             assert.deepEqual(!!node.value, true);
             assert.deepEqual(!!node.value.specRoot, true);


### PR DESCRIPTION
wikimedia/swagger-router#52 introduces a
separation between metadata-only nodes & actual routes. This separation
avoids conflicts, like metadata-only nodes overriding wildcard matches.

This patch uses this separation in hyperswitch to store API root
information.

Depends on: wikimedia/swagger-router#52 /
swagger-router v0.5.5.