### PR TITLE
Allow docs to connect to anything

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -57,7 +57,7 @@ function staticServe(hyper, req) {
             headers: {
                 'content-type': contentType,
                 'content-security-policy': "default-src 'none'; " +
-                    "script-src 'self' 'unsafe-inline'; connect-src 'self'; " +
+                    "script-src 'self' 'unsafe-inline'; connect-src *; " +
                     "style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self';"
             },
             body


### PR DESCRIPTION
Sometimes we do cross-domain redirects for example for files stored on commons - we need to allow docs to fetch that content.

Bug: https://phabricator.wikimedia.org/T151653