### PR TITLE
Clean up the spec we're producing

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -339,8 +339,10 @@ class Router {
                 }
             }
 
-            node.value.methods[methodName] = reqHandler || {};
-            node.value.methods[methodName].spec = method;
+            if (reqHandler || this._options.dry_run) {
+                node.value.methods[methodName] = reqHandler || {};
+                node.value.methods[methodName].spec = method;
+            }
         });
     }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -332,13 +332,13 @@ class Router {
                 });
             } else if (method.operationId) {
                 reqHandler = scope.operations[method.operationId];
-                if (!reqHandler && !this._options.dry_run) {
+                if (!reqHandler && !this._options.disable_handlers) {
                     throw new Error(`No known handler associated with operationId ${
                          method.operationId}`);
                 }
             }
 
-            if (reqHandler || this._options.dry_run) {
+            if (reqHandler || this._options.disable_handlers) {
                 node.value.methods[methodName] = reqHandler || {};
                 node.value.methods[methodName].spec = method;
             }

--- a/lib/router.js
+++ b/lib/router.js
@@ -296,7 +296,6 @@ class Router {
                 delete methodCopy['x-setup-handler'];
                 delete methodCopy['x-request-handler'];
                 delete methodCopy['x-route-filters'];
-                delete methodCopy.operationId;
                 specPaths[scope.prefixPath][methodName] = methodCopy;
             }
 
@@ -333,7 +332,7 @@ class Router {
                 });
             } else if (method.operationId) {
                 reqHandler = scope.operations[method.operationId];
-                if (!reqHandler) {
+                if (!reqHandler && !this._options.dry_run) {
                     throw new Error(`No known handler associated with operationId ${
                          method.operationId}`);
                 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -292,7 +292,12 @@ class Router {
                 if (!specPaths[scope.prefixPath]) {
                     specPaths[scope.prefixPath] = {};
                 }
-                specPaths[scope.prefixPath][methodName] = method;
+                const methodCopy = Object.assign({}, method);
+                delete methodCopy['x-setup-handler'];
+                delete methodCopy['x-request-handler'];
+                delete methodCopy['x-route-filters'];
+                delete methodCopy.operationId;
+                specPaths[scope.prefixPath][methodName] = methodCopy;
             }
 
             if ({}.hasOwnProperty.call(node.value.methods, methodName)) {
@@ -334,10 +339,8 @@ class Router {
                 }
             }
 
-            if (reqHandler) {
-                node.value.methods[methodName] = reqHandler;
-                node.value.methods[methodName].spec = method;
-            }
+            node.value.methods[methodName] = reqHandler || {};
+            node.value.methods[methodName].spec = method;
         });
     }
 
@@ -615,6 +618,8 @@ Router.prototype._createNewApiRoot = (node, spec, scope) => {
     specRoot.securityDefinitions = spec.securityDefinitions || {};
     specRoot['x-default-params'] = spec['x-default-params'] || {};
     specRoot.tags = spec.tags || [];
+
+    delete specRoot['x-route-filters'];
 
     // Reset paths. These are going to be built up during path setup.
     specRoot.paths = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
1. Don't expose internal stuff in the public spec
2. If the operationId doesn't exist and there's a dry-run flag set in the options - just load the spec.

cc @wikimedia/services 