### PR TITLE
Fix swagger option mangling

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -31,9 +31,9 @@ function staticServe(hyper, req) {
                 .replace(/<title>[^<]*<\/title>/, `<title>${cfg.ui_title}</title>`)
                 // Replace the default url with ours, switch off validation &
                 // limit the size of documents to apply syntax highlighting to
-                .replace(/Sorter: "alpha"/, 'Sorter: "alpha", validatorUrl: null, ' +
-                    'highlightSizeThreshold: 10000')
-                .replace(/docExpansion: "none"/, 'docExpansion: "list"')
+                .replace(/docExpansion: "none"/, 'docExpansion: "list", '
+                    + 'validatorUrl: null, '
+                    + 'highlightSizeThreshold: 10000')
                 .replace(/ url: url,/, 'url: "?spec",');
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The Sorter option we previously relied on for a part of our swagger UI
option mangling pass was removed. This meant that some of the options we
used to set were no longer making it into the HTML.

This patch moves those options to another replace, which does exist.
Among other things, this fixes
https://phabricator.wikimedia.org/T170729.

Bug: https://phabricator.wikimedia.org/T170729