### PR TITLE
Fix route parsing when concrete and wildcard paths overlap

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -53,7 +53,7 @@ class Router {
         const params = {};
         for (let i = 0; i < path.length; i++) {
             const segment = path[i];
-            let nextNode = node.getChild(segment, params);
+            let nextNode = node.getChild(segment, params, true);
             if (!nextNode) {
                 nextNode = new Node();
                 node.setChild(segment, nextNode);
@@ -426,7 +426,7 @@ class Router {
 
                 // Check if the subtree already exists, which can happen when
                 // specs are overlapping.
-                subtree = branchNode.getChild(segment, {});
+                subtree = branchNode.getChild(segment, {}, true);
                 if (!subtree) {
                     // Build a new subtree
                     subtree = new Node();


### PR DESCRIPTION
When building a node tree from a set of paths, unrelated paths
were incorrectly coalesced (or not, depengin on path order). E.g.

    path 1: /{var}/bar
    path 2: /foo/baz
    Expected: { foo: { baz: {} }, '*': { bar: {} } }
    Actual: { '*': { bar: {}, baz: {} } }

Use exact the new match exactness parameter in Node.getChild
to prevent this.

The swagger-router part of the patch is wikimedia/swagger-router#56.