### PR TITLE
Allow validators to use references to definitions

### DIFF
--- a/lib/filters/validator.js
+++ b/lib/filters/validator.js
@@ -44,8 +44,17 @@ const supportedValidators = ['maximum',
  * @constructor
  */
 class Validator {
-    constructor(parameters) {
+    constructor(parameters, definitions) {
         this._ajv = constructAjv({ verbose: true });
+        if (definitions) {
+            Object.keys(definitions).forEach((schemaName) => {
+                this._ajv.addSchema(
+                    definitions[schemaName],
+                    `#/definitions/${schemaName}`
+                );
+            });
+        }
+
         this._paramCoercionFunc = this._createTypeCoercionFunc(parameters.filter((p) => {
             return p.in !== 'formData' && p.in !== 'body' && p.type !== 'string';
         }));
@@ -247,7 +256,10 @@ module.exports = (hyper, req, next, options, specInfo) => {
         if (cachedValidator) {
             cachedValidator.validate(req);
         } else {
-            const validator = new Validator(specInfo.spec.parameters);
+            const validator = new Validator(
+                specInfo.spec.parameters,
+                specInfo.specRoot && specInfo.specRoot.definitions
+            );
             CACHE.set(specInfo.spec, validator);
             validator.validate(req);
         }

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -217,7 +217,8 @@ class HyperSwitch {
             const childHyperSwitch = this.makeChild(req, options);
             const reqHandler = childHyperSwitch._createFilteredHandler(handler, match.filters, {
                 path: match.value.path,
-                spec: handler.spec
+                spec: handler.spec,
+                specRoot: match.value.specRoot
             });
             // This is a hack. Pure P.try get's executed on this tick, but we wanna
             // wrap it in metrics and access checks and start execution only afterwards.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/filters/validator.js
+++ b/test/filters/validator.js
@@ -6,7 +6,7 @@
 var assert = require('./../utils/assert.js');
 var validator = require('../../lib/filters/validator');
 
-var testValidator = function (req, parameters, example) {
+var testValidator = function (req, parameters, example, definitions) {
     return validator(null, req, function (hyper, req) {
         if (example) {
             assert.deepEqual(req, example);
@@ -14,6 +14,9 @@ var testValidator = function (req, parameters, example) {
     }, null, {
         spec: {
             parameters: parameters
+        },
+        specRoot: {
+            definitions: definitions
         }
     });
 };
@@ -285,5 +288,36 @@ describe('Validator filter', function () {
             assert.deepEqual(e.body.detail, "data.query.queryParam should be equal to " +
                 "one of the allowed values: [one, two, three]");
         }
+    });
+
+    it('Should support refs to definitions for parameters', () => {
+        testValidator({
+            body: {
+                test_value: 'four',
+                int_test_value: 4
+            }
+        }, [
+            {
+                name: 'bodyParam',
+                in: 'body',
+                type: 'object',
+                schema: {
+                    $ref: '#/definitions/test_schema'
+                },
+                required: 'true'
+            }
+        ], undefined, {
+            test_schema: {
+                type: 'object',
+                parameters: {
+                    test_value: {
+                        type: 'string'
+                    },
+                    int_test_value: {
+                        type: 'integer'
+                    }
+                }
+            }
+        });
     });
 });


### PR DESCRIPTION
Fairly easy top add all the definitions to all the validators so that we can reuse `$ref` if param validation.

Bug: https://phabricator.wikimedia.org/T176689