### PR TITLE
Add a Server header to the response

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,7 @@ const url = require('url');
 const http = require('http');
 const zlib = require('zlib');
 const stream = require('stream');
+const os = require('os');
 
 const URI = require('swagger-router').URI;
 
@@ -138,6 +139,8 @@ function handleResponse(opts, req, resp, response) {
 
         // Propagate the request id header
         rh['x-request-id'] = opts.reqId;
+
+        rh['server'] = os.hostname();
 
         logResponse(opts, response, opts.startTime);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -140,7 +140,7 @@ function handleResponse(opts, req, resp, response) {
         // Propagate the request id header
         rh['x-request-id'] = opts.reqId;
 
-        rh['server'] = os.hostname();
+        rh.server = os.hostname();
 
         logResponse(opts, response, opts.startTime);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
MediaWiki is setting a Server header to tell which exact server server the request. Do the same, useful for debugging.

cc @wikimedia/services 