### PR TITLE
Exported factory that wraps generic Error in HTTPError; release v0.9.6

### DIFF
--- a/lib/exports.js
+++ b/lib/exports.js
@@ -57,6 +57,32 @@ class HTTPError extends Error {
         }
         Object.assign(this, response);
     }
+
+    /**
+     * Factory function wrapping generic JS Error to HTTPError
+     * @param {Error} e original error
+     * @return {HTTPError}
+     */
+    static fromError(e) {
+        if (e && e.name === 'HTTPError') {
+            return e;
+        }
+        const originalError = e;
+        const stack = e && e.stack;
+        e = new HTTPError({
+            status: 500,
+            body: {
+                type: 'internal_error',
+                description: `${e}`
+                // Probably better to keep this private for now
+                // stack: e.stack
+            }
+        });
+        // Log this internally
+        e.stack = stack;
+        e.innerError = originalError;
+        return e;
+    }
 }
 
 exporting.HTTPError = HTTPError;

--- a/lib/server.js
+++ b/lib/server.js
@@ -367,20 +367,7 @@ function handleRequest(opts, req, resp) {
     })
     .catch((e) => {
         if (!e || e.name !== 'HTTPError') {
-            const originalError = e;
-            const stack = e && e.stack;
-            e = new exporting.HTTPError({
-                status: 500,
-                body: {
-                    type: 'internal_error',
-                    description: `${e}`
-                    // Probably better to keep this private for now
-                    // stack: e.stack
-                }
-            });
-            // Log this internally
-            e.stack = stack;
-            e.innerError = originalError;
+            e = exporting.HTTPError.fromError(e);
         }
         if (!e.status) {
             e.status = 500;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We need to reuse it in RESTBase filter, so to avoid code duplication export it.

cc @wikimedia/services 