### PR TITLE
Deprecate the use of the options.log or hyper.log

### DIFF
--- a/lib/filters/http.js
+++ b/lib/filters/http.js
@@ -30,7 +30,7 @@ module.exports = (hyper, req, next, options) => {
     // access to logstash, so always set / forward it.
     hyper.setRequestId(req);
 
-    hyper.log('trace/webrequest', {
+    hyper.logger.log('trace/webrequest', {
         request_id: req.headers['x-request-id'],
         req,
     });

--- a/lib/filters/ratelimit_route.js
+++ b/lib/filters/ratelimit_route.js
@@ -21,7 +21,7 @@ module.exports = (hyper, req, next, options, specInfo) => {
 
     const key = `${pathKey}|${hyper._rootReq.headers['x-client-ip']}`;
     if (hyper.ratelimiter.isAboveLimit(key, options.limits[requestClass])) {
-        hyper.log(`warn/ratelimit/${pathKey}`, {
+        hyper.logger.log(`warn/ratelimit/${pathKey}`, {
             key,
             rate_limit_per_second: options.limits[requestClass],
             message: 'Rate limit exceeded'

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -38,9 +38,6 @@ class HyperSwitch {
             const par = options;
             parOptions = parOptions || {};
             this.logger = parOptions.logger || par.logger;
-            // TODO: added for backwards compatibility.
-            // Remove when clients stop using hyper.log directly and switch to using logger
-            this.log = this.logger.log.bind(this.logger);
             this.metrics = parOptions.metrics || par.metrics;
             this.ratelimiter = parOptions.ratelimiter || par.ratelimiter;
             this.reqId = par.reqId ||

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -37,7 +37,10 @@ class HyperSwitch {
             // Child instance
             const par = options;
             parOptions = parOptions || {};
-            this.log = parOptions.log || par.log;
+            this.logger = parOptions.logger || par.logger;
+            // TODO: added for backwards compatibility.
+            // Remove when clients stop using hyper.log directly and switch to using logger
+            this.log = this.logger.log.bind(this.logger);
             this.metrics = parOptions.metrics || par.metrics;
             this.ratelimiter = parOptions.ratelimiter || par.ratelimiter;
             this.reqId = par.reqId ||
@@ -63,7 +66,10 @@ class HyperSwitch {
             };
         } else {
             // Brand new instance
-            this.log = options.log; // Logging method
+            this.logger = options.logger;
+            // TODO: added for backwards compatibility.
+            // Remove when clients stop using hyper.log directly and switch to using logger
+            this.log = this.logger.log.bind(this.logger);
             this.metrics = options.metrics;
             this.ratelimiter = options.ratelimiter;
             this.reqId = null;
@@ -227,7 +233,7 @@ class HyperSwitch {
 
             return reqHandlerPromise
             .then((res) => {
-                childHyperSwitch.log('trace/hyper/response', {
+                childHyperSwitch.logger.log('trace/hyper/response', {
                     req,
                     res,
                     request_id: childHyperSwitch.reqId
@@ -359,7 +365,7 @@ HyperSwitch.prototype.defaultListingHandler = (match, hyper, req) => {
 };
 
 HyperSwitch.prototype._isSysRequest = req => (req.params && req.params.api === 'sys')
-    // TODO: Remove once params.api is reliable
+// TODO: Remove once params.api is reliable
         || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys');
 
 HyperSwitch.prototype._createFilteredHandler = (handler, filters, specInfo) => {

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -64,9 +64,6 @@ class HyperSwitch {
         } else {
             // Brand new instance
             this.logger = options.logger;
-            // TODO: added for backwards compatibility.
-            // Remove when clients stop using hyper.log directly and switch to using logger
-            this.log = this.logger.log.bind(this.logger);
             this.metrics = options.metrics;
             this.ratelimiter = options.ratelimiter;
             this.reqId = null;

--- a/lib/router.js
+++ b/lib/router.js
@@ -115,8 +115,12 @@ class Router {
         }
 
         // Append the log property to module options, if it is not present
+        // TODO: Eventually get rid of this, added for backwards compatibility.
+        // When clients stop using the bound log method provided in the options
+        // and switch to using hyper.logger directly, this will not be needed any more
         if (!options.log) {
-            options.log = this._options.log || (() => {});
+            options.log = this._options.logger
+                && this._options.logger.log.bind(this._options.logger) || (() => {});
         }
         return options;
     }
@@ -206,7 +210,7 @@ class Router {
         const constructModule = (spec) => {
             const mod = {
                 spec,
-                globals: { options, log: options.log },
+                globals: { options },
                 // Needed to check cache validity.
                 _parentGlobals: globals,
             };
@@ -237,7 +241,6 @@ class Router {
                     throw new Error(`No operations exported by module ${loadPath}`);
                 }
                 if (!mod.globals) { mod.globals = {}; }
-                mod.globals.log = options.log;
                 // Needed to check cache validity.
                 mod._parentGlobals = globals;
                 this._modules.set(modDef, mod);
@@ -597,7 +600,7 @@ class Router {
     /**
      * Resolve an URI to a value object
      * Main request routing entry point.
-     * @param {URI|String} uri URI object
+     * @param {URI|string} uri URI object
      * @return {Object} match:
      * - @prop {Object} value:
      *   - @prop {Object} methods: handlers for methods like get, post etc

--- a/lib/router.js
+++ b/lib/router.js
@@ -115,12 +115,14 @@ class Router {
         }
 
         // Append the log property to module options, if it is not present
-        // TODO: Eventually get rid of this, added for backwards compatibility.
-        // When clients stop using the bound log method provided in the options
-        // and switch to using hyper.logger directly, this will not be needed any more
+        if (!options.logger) {
+            options.logger = this._options.logger;
+        }
         if (!options.log) {
-            options.log = this._options.logger
-                && this._options.logger.log.bind(this._options.logger) || (() => {});
+            // TODO: Eventually get rid of this, added for backwards compatibility.
+            // When clients stop using the bound log method provided in the options
+            // and switch to using hyper.logger directly, this will not be needed any more
+            options.log = this._options.logger.log.bind(this._options.logger) || (() => {});
         }
         return options;
     }

--- a/lib/router.js
+++ b/lib/router.js
@@ -118,12 +118,6 @@ class Router {
         if (!options.logger) {
             options.logger = this._options.logger;
         }
-        if (!options.log) {
-            // TODO: Eventually get rid of this, added for backwards compatibility.
-            // When clients stop using the bound log method provided in the options
-            // and switch to using hyper.logger directly, this will not be needed any more
-            options.log = this._options.logger.log.bind(this._options.logger) || (() => {});
-        }
         return options;
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -106,7 +106,7 @@ function logResponse(opts, response, startTime) {
     if (latency > 5000) {
         logLevel = 'debug/request/slow';
     }
-    opts.log(logLevel, {
+    opts.logger.log(logLevel, {
         message: response.message || 'Request sample',
         res: {
             status: response.status,
@@ -117,7 +117,7 @@ function logResponse(opts, response, startTime) {
     });
 
     if (response.status >= 500) {
-        opts.log('error/request', {
+        opts.logger.log('error/request', {
             message: response.message,
             res: response,
             stack: response.stack,
@@ -233,7 +233,7 @@ function handleResponse(opts, req, resp, response) {
             resp.end();
         }
     } else {
-        opts.log('error/request', {
+        opts.logger.log('error/request', {
             root_req: req,
             response: response.stack || response.toString(),
             msg: "No content returned"
@@ -272,7 +272,6 @@ function handleRequest(opts, req, resp) {
 
     const reqOpts = {
         conf: opts.conf,
-        log: null,
         reqId: req.headers['x-request-id'],
         metrics: opts.metrics,
         ratelimiter: opts.ratelimiter,
@@ -301,7 +300,7 @@ function handleRequest(opts, req, resp) {
     }
 
     // Create a child logger with selected request information.
-    reqOpts.logger = opts.logger && opts.logger.child({
+    reqOpts.logger = opts.logger.child({
         root_req: {
             method: req.method.toLowerCase(),
             uri: req.url,
@@ -321,7 +320,6 @@ function handleRequest(opts, req, resp) {
         },
         request_id: req.headers['x-request-id']
     });
-    reqOpts.log = reqOpts.logger && reqOpts.logger.log.bind(reqOpts.logger) || (() => {});
 
     // Create a new, clean request object
     const urlData = parseURL(req.url);
@@ -351,7 +349,7 @@ function handleRequest(opts, req, resp) {
                 try {
                     body = JSON.parse(bodyStr);
                 } catch (e) {
-                    reqOpts.log('error/request/json-parsing', e);
+                    reqOpts.logger.log('error/request/json-parsing', e);
                 }
             }
         }
@@ -384,8 +382,7 @@ function main(options) {
     const opts = {
         appBasePath: options.appBasePath,
         conf,
-        logger: options.logger,
-        log: options.logger && options.logger.log.bind(options.logger) || (() => {}),
+        logger: options.logger || utils.nullLogger,
         metrics: options.metrics,
         ratelimiter: options.ratelimiter,
         child_metrics: {
@@ -416,7 +413,7 @@ function main(options) {
         const host = conf.host;
         // Apply some back-pressure.
         main.server.listen(port, host);
-        opts.log('warn/startup', `listening on ${host || '*'}:${port}`);
+        opts.logger.log('warn/startup', `listening on ${host || '*'}:${port}`);
         // Don't delay incomplete packets for 40ms (Linux default) on
         // pipelined HTTP sockets. We write in large chunks or buffers, so
         // lack of coalescing should not be an issue here.
@@ -434,7 +431,7 @@ function main(options) {
         return main.server;
     })
     .catch((e) => {
-        opts.log('fatal/startup', {
+        opts.logger.log('fatal/startup', {
             status: e.status,
             err: e,
             stack: e.body && e.body.stack || e.stack

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,4 +60,24 @@ utils.constructRegex = (variants) => {
     return regex;
 };
 
+/**
+ * In case a logger is not provided, use this class as a replacement
+ * to avoid TypeErrors and undefined logger instances. \
+ *
+ * Added for backwards compatibility, since not all the clients are ready to
+ * undefined logger instance.
+ */
+class NullLogger {
+    log() {
+        // no-op
+    }
+    child() {
+        return new NullLogger();
+    }
+    close() {
+        // no-op
+    }
+}
+utils.nullLogger = new NullLogger();
+
 module.exports = utils;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.10.0",
+  "version": "0.9.6",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/router/buildTree.js
+++ b/test/router/buildTree.js
@@ -7,8 +7,10 @@ var Router = require('../../lib/router');
 var assert = require('../utils/assert');
 var fs     = require('fs');
 var yaml   = require('js-yaml');
+const util = require('../../lib/utils');
 
 var fakeHyperSwitch = { config: {} };
+const ROUTER_OPTS = { appBasePath: __dirname, logger: util.nullLogger };
 
 var noopResponseHanlder = {
     'x-request-hander': [
@@ -79,7 +81,7 @@ var nestedSecuritySpec = {
 describe('Router', function() {
 
     it('should allow adding methods to existing paths', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec(additionalMethodSpec, fakeHyperSwitch)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
@@ -89,7 +91,7 @@ describe('Router', function() {
     });
 
     it('should error on overlapping methods on the same path', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec(overlappingMethodSpec, fakeHyperSwitch)
         .then(function() {
             throw new Error("Should throw an exception!");
@@ -100,7 +102,7 @@ describe('Router', function() {
     });
 
     it('should pass permission along the path to endpoint', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec(nestedSecuritySpec, fakeHyperSwitch)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/secure');
@@ -113,7 +115,7 @@ describe('Router', function() {
         });
     });
     it('should fail when no handler found for method', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec(noHandlerSpec, fakeHyperSwitch)
         .then(function() {
             throw new Error("Should throw an exception!");
@@ -126,7 +128,7 @@ describe('Router', function() {
 
     it('should not modify top-level spec-root', function() {
         var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/multi_domain_spec.yaml'));
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec(spec, fakeHyperSwitch)
         .then(function() {
             var node = router.route('/test2');
@@ -135,7 +137,7 @@ describe('Router', function() {
     });
 
     it('support loading modules from absolute paths', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: {
                 '/test': {
@@ -148,7 +150,7 @@ describe('Router', function() {
     });
 
     it('supports merging api specs from different modules', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: {
                 '/test': {
@@ -174,7 +176,7 @@ describe('Router', function() {
     });
 
     it('supports exposing top-level spec', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec(yaml.safeLoad(fs.readFileSync(__dirname + '/root_api_spec.yaml')), fakeHyperSwitch)
         .then(function() {
             var node = router.route([{ type: 'meta', name: 'apiRoot' }]);
@@ -190,7 +192,7 @@ describe('Router', function() {
     });
 
     it('supports recursive matching with + modifier', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: {
                 '/test/{+rest}': noopResponseHanlder
@@ -204,7 +206,7 @@ describe('Router', function() {
     });
 
     it('supports optional matching', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: {
                 '/test{/rest}': noopResponseHanlder
@@ -221,14 +223,14 @@ describe('Router', function() {
     });
 
     it('does not explode on empty spec', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: { }
         }, fakeHyperSwitch);
     });
 
     it('passes options to modules', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         // The error is thrown by options_testing_module in case options are not passed correctly
         return router.loadSpec({
             paths: {
@@ -253,7 +255,7 @@ describe('Router', function() {
     });
 
     it('calls resources when module is created', function(done) {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         router.loadSpec({
             paths: {
                 '/test': {
@@ -285,7 +287,7 @@ describe('Router', function() {
     });
 
     it('finds module with in app basePath node_modules', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: {
                 '/test': {
@@ -303,7 +305,7 @@ describe('Router', function() {
     });
 
     it('throws error if module is not found', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: {
                 '/test': {
@@ -324,7 +326,7 @@ describe('Router', function() {
     });
 
     it('throws error on invalid modules definition', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: {
                 '/test': {
@@ -342,7 +344,7 @@ describe('Router', function() {
     });
 
     it('supports multiple optional parameters', function() {
-        var router = new Router({ appBasePath: __dirname });
+        var router = new Router(ROUTER_OPTS);
         return router.loadSpec({
             paths: {
                 '/test{/key1}{/key2}': {

--- a/test/router/options_testing_module.js
+++ b/test/router/options_testing_module.js
@@ -6,7 +6,7 @@ module.exports = function(options) {
     assert.deepEqual(options.simple_option, 'simple_option_value');
     assert.deepEqual(options.templated_option, 'test_conf_option_value');
     assert.deepEqual(options.templates, { sample_template: '{{should not be expanded}}' });
-    assert.deepEqual(typeof options.log, 'function');
+    assert.deepEqual(!!options.logger, true );
     return {
         spec: {
             paths: {


### PR DESCRIPTION
By exposing the bound log functions like options.log or hyper.log
instead of forcing clients to use the hyper.logger object directly,
we mask a powerful ability to add childer loggers to the exposed
logger from clients. Also, hyper itself can not augment the logger
on the per-request basis, for example, to add the URI spec to the request
after the match succeeded. All clients should only use hyper.logger
to log.

The current change is backward compatible, but the fallbacks will be removed
as soon as RESTbase and change-prop adapt to the new logging method.

Examples where this is critical to implement:
- https://phabricator.wikimedia.org/T189358
- globally adding rule_name to the logger in change-prop for better filtering in logstash

cc @wikimedia/services 