### PR TITLE
Fix tests for new preq retry defaults

### DIFF
--- a/test/handlerTemplate/general.js
+++ b/test/handlerTemplate/general.js
@@ -116,7 +116,10 @@ describe('Handler Template', function() {
         var api = nock('http://mocked_domain_for_tests.com')
         .get('/TestTitle').reply(500, 'SERVER_ERROR', { 'Content-Type': 'text/plain' });
 
-        return preq.get({ uri: server.hostPort + '/service/return_if_test/TestTitle' })
+        return preq.get({
+            uri: server.hostPort + '/service/return_if_test/TestTitle',
+            retries: 0
+        })
         .then(function () {
             throw new Error('Error should be thrown');
         }, function(e) {

--- a/test/handlerTemplate/test_config.yaml
+++ b/test/handlerTemplate/test_config.yaml
@@ -36,6 +36,7 @@ spec_root: &spec_root
           - get_from_api:
               request:
                 uri: http://mocked_domain_for_tests.com/{title}
+                retries: 0
               return_if:
                 status: '2xx'
               catch:


### PR DESCRIPTION
After 0.5.7 the preq retrie semantics was fixed, while these tests relied on nock, so the fixed retry semantics has broken them.

cc @wikimedia/services 