### PR TITLE
Replace `json-stable-stringify` with `fast-json-stable-stringify`

### DIFF
--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -7,7 +7,7 @@
 
 const P = require('bluebird');
 const Template = require('swagger-router').Template;
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 
 /**
  * Creates a JS function that verifies property equality

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {
@@ -25,16 +25,16 @@
   },
   "homepage": "https://github.com/wikimedia/hyperswitch",
   "dependencies": {
+    "ajv": "^6.5.4",
     "bluebird": "^3.5.2",
     "busboy": "^0.2.14",
-    "js-yaml": "^3.12.0",
     "cassandra-uuid": "^0.1.0",
+    "fast-json-stable-stringify": "^2.0.0",
+    "js-yaml": "^3.12.0",
     "preq": "^0.5.6",
+    "regexp-utils": "^0.3.2",
     "swagger-router": "^0.7.2",
-    "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
-    "json-stable-stringify": "^1.0.1",
-    "ajv": "^6.5.4",
-    "regexp-utils": "^0.3.2"
+    "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",


### PR DESCRIPTION
fast-json-stable-stringify is being used because it does not have any dependencies and has been shown to be faster than json-stable-stringify

Bug: T210426