### PR TITLE
Remove duplicate tags

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -510,7 +510,17 @@ class Router {
         // added to the higher level spec?
         Object.assign(scope.specRoot.definitions, spec.definitions);
         Object.assign(scope.specRoot.securityDefinitions, spec.securityDefinitions);
-        scope.specRoot.tags = scope.specRoot.tags.concat(spec.tags || []);
+        scope.specRoot.tags = scope.specRoot.tags.concat(spec.tags || [])
+            .filter((tag, index, self) => {
+                return index === self.findIndex((t) => {
+                    if (t.name === tag.name) {
+                        if (t.description !== tag.description) {
+                            throw new Error(`Tags ${t.name} must have the same descriptions.`);
+                        }
+                        return true;
+                    }
+                });
+            });
 
         this._loadRouteFilters(node, spec, scope);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updated router to remove duplicate tags; necessary for swagger
validation.

Bug: T218218