### PR TITLE
Stringify the request URI in http filter

### DIFF
--- a/lib/filters/http.js
+++ b/lib/filters/http.js
@@ -6,7 +6,7 @@ const regexUtils = require('regexp-utils');
 
 module.exports = (hyper, req, next, options) => {
     options = options || {};
-    const host = req.uri.constructor === String ? req.uri : req.uri.protoHost;
+    const uri = req.uri.toString();
     let match;
     if (options.allow) {
         if (!options._cache.allowSwitch) {
@@ -15,18 +15,16 @@ module.exports = (hyper, req, next, options) => {
             });
             options._cache.allowSwitch = regexUtils.makeRegExpSwitch(options.allow);
         }
-        match = options._cache.allowSwitch(host);
+        match = options._cache.allowSwitch(uri);
     } else {
-        match = /^https?:\/\//.test(host) ? { matcher: { forward_headers: false } } : null;
+        match = /^https?:\/\//.test(uri) ? { matcher: { forward_headers: false } } : null;
     }
 
     if (!match) {
         return next(hyper, req);
     }
 
-    // Make sure we have a string
-    req.uri = `${req.uri}`;
-    // The request ID is not personally identifyable information without
+    // The request ID is not personally identifiable information without
     // access to logstash, so always set / forward it.
     hyper.setRequestId(req);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/router/buildTree.js
+++ b/test/router/buildTree.js
@@ -6,6 +6,7 @@ var assert = require('../utils/assert');
 var fs     = require('fs');
 var yaml   = require('js-yaml');
 const util = require('../../lib/utils');
+const URI  = require('swagger-router').URI;
 
 var fakeHyperSwitch = { config: {} };
 const ROUTER_OPTS = { appBasePath: __dirname, logger: util.nullLogger };
@@ -288,7 +289,7 @@ describe('Router',() => {
                 try {
                     var expectedRequest = {
                         method: 'post',
-                        uri: '/testing/uri/that/will/be/checked/by/test',
+                        uri: new URI('/testing/uri/that/will/be/checked/by/test'),
                         headers: {
                             test: 'test'
                         },


### PR DESCRIPTION
After the request.uri is an instance of URI we can't properly match on it, so stringify the URI before matching.

Also, we don't need to re-stringify it before passing onto preq after recent changes to preq.