### PR TITLE
Allow paths to be hidden in the spec; release v0.12.4

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -142,7 +142,7 @@ class HyperSwitch {
      * @private
      */
     _checkInternalApiRequest(req) {
-        if (this._recursionDepth === 0 && this._isSysRequest(req)) {
+        if (this._recursionDepth === 0 && this.isSysRequest(req)) {
             throw new HTTPError({
                 status: 403,
                 body: {
@@ -287,6 +287,30 @@ function getDocBasePath(req, spec) {
     }
     return req.uri.toString().replace(/\/$/, '');
 }
+
+function filterSpec(spec) {
+    let ret = {};
+    if (!spec) {
+        return spec;
+    }
+    if (spec.constructor === Object) {
+        if (spec['x-hidden']) {
+            return null;
+        }
+        Object.keys(spec).forEach((key) => {
+            ret[key] = filterSpec(spec[key]);
+            if (ret[key] === null) {
+                delete ret[key];
+            }
+        });
+        return ret;
+    }
+    if (Array.isArray(spec)) {
+        return spec.map(filterSpec).filter((x) => x !== null);
+    }
+    return spec;
+}
+
 // A default listing handler for URIs that end in / and don't have any
 // handlers associated with it otherwise.
 HyperSwitch.prototype.defaultListingHandler = function (match, hyper, req) {
@@ -295,7 +319,7 @@ HyperSwitch.prototype.defaultListingHandler = function (match, hyper, req) {
             match.value.specRoot && !match.value.specRoot['x-listing']) {
         return P.resolve({
             status: 200,
-            body: Object.assign({}, match.value.specRoot, {
+            body: Object.assign({}, filterSpec(match.value.specRoot), {
                 // Set the base path dynamically
                 servers: [{ url: getDocBasePath(req, match.value.specRoot) }]
             })
@@ -364,9 +388,12 @@ HyperSwitch.prototype.defaultListingHandler = function (match, hyper, req) {
     }
 };
 
-HyperSwitch.prototype._isSysRequest = (req) => (req.params && req.params.api === 'sys') ||
+HyperSwitch.prototype.isSysRequest = (req) => (req.params && req.params.api === 'sys') ||
         // TODO: Remove once params.api is reliable
         (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys');
+
+// Deprecated, kept for compat with older versions
+HyperSwitch.prototype._isSysRequest = HyperSwitch.prototype.isSysRequest;
 
 HyperSwitch.prototype._createFilteredHandler = function (handler, filters, specInfo) {
     if (!filters || !filters.length) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -13,6 +13,9 @@ const Template = swaggerRouter.Template;
 const URI = swaggerRouter.URI;
 const SwaggerRouter = swaggerRouter.Router;
 
+// list of x-* path items that are allowed to make it in the spec
+const PATH_ITEMS_WHITELIST = ['x-hidden'];
+
 /**
  *
  * @param {Object} init
@@ -283,19 +286,21 @@ class Router {
      */
     _registerMethods(node, pathspec, scope) {
         Object.keys(pathspec).forEach((methodName) => {
+            const specPaths = scope.specRoot.paths;
+            const method = pathspec[methodName];
             if (/^x-/.test(methodName)) {
+                if (PATH_ITEMS_WHITELIST.includes(methodName)) {
+                    specPaths[scope.prefixPath] = specPaths[scope.prefixPath] || {};
+                    specPaths[scope.prefixPath][methodName] = method;
+                }
                 return;
             }
-            const method = pathspec[methodName];
-            const specPaths = scope.specRoot.paths;
             // Insert the method spec into the global merged spec
             if (method && !method['x-hidden'] &&
                     (!specPaths[scope.prefixPath] ||
                         !specPaths[scope.prefixPath][methodName])) {
                 // Register the path in the specRoot
-                if (!specPaths[scope.prefixPath]) {
-                    specPaths[scope.prefixPath] = {};
-                }
+                specPaths[scope.prefixPath] = specPaths[scope.prefixPath] || {};
                 const methodCopy = Object.assign({}, method);
                 delete methodCopy['x-setup-handler'];
                 delete methodCopy['x-request-handler'];

--- a/lib/server.js
+++ b/lib/server.js
@@ -284,7 +284,7 @@ function handleRequest(opts, req, resp) {
      * request are thus recorded in .internal or .internal_update prefixed
      * metric trees.
      */
-    if (/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
+    if (/^::1|(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
         if (req.headers['cache-control'] && /no-cache/i.test(req.headers['cache-control'])) {
             reqOpts.metrics = opts.child_metrics.internal_update;
             req.headers['x-request-class'] = 'internal_update';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/hyperswitch/docs.js
+++ b/test/hyperswitch/docs.js
@@ -34,6 +34,27 @@ describe('Documentation handling',() => {
         });
     });
 
+    it('should retrieve the spec without skipped items', () => {
+        return preq.get({
+            uri: server.hostPort + '/v1/?spec'
+        })
+        .then((res) => {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, 'application/json');
+            assert.deepEqual(res.body.paths.hasOwnProperty('/test/test3'), false);
+        });
+    });
+
+    it('should answer requests for paths skipped in the spec', () => {
+        return preq.get({
+            uri: server.hostPort + '/v1/test/test3'
+        })
+        .then((res) => {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body, 'test3');
+        });
+    });
+
     it('should retrieve the swagger-ui main page',() => {
         return preq.get({
             uri: server.hostPort + '/v1/',

--- a/test/hyperswitch/docs_config.yaml
+++ b/test/hyperswitch/docs_config.yaml
@@ -19,6 +19,14 @@ spec_root: &spec_root
                         return:
                           status: 200
                           body: 'test2'
+              /test/test3:
+                x-hidden: true
+                get:
+                  x-request-handler:
+                    - return_result:
+                        return:
+                          status: 200
+                          body: 'test3'
     /{api:sys}/test/:
       x-modules:
         - type: inline


### PR DESCRIPTION
Certain paths, while accessible, may want to be hidden when clients
query for the spec. Here we allow spec authors to hide paths by using
the `x-hidden` path stanza.

Also, expose the `HyperSwitch.isSysRequest()` method.