### PR TITLE
Correctly pass options for JS modules; release v0.12.5

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -244,7 +244,7 @@ class Router {
                 if (!mod.operations && !mod.globals) {
                     throw new Error(`No operations exported by module ${loadPath}`);
                 }
-                mod.globals = mod.globals || {};
+                mod.globals = mod.globals || { options };
                 // Needed to check cache validity.
                 mod._parentGlobals = globals;
                 this._modules.set(modDef, mod);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In case the JS module doesn't explicitly reexport its options to the yaml config, correctly default to reexporting the options.