### PR TITLE
Have proper module caching and sharing

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -3,6 +3,8 @@
 const P = require('bluebird');
 const yaml = require('js-yaml');
 const fs = P.promisifyAll(require('fs'));
+const stringify = require('fast-json-stable-stringify');
+const crypto = require('crypto');
 const handlerTemplate = require('./handlerTemplate');
 const swaggerRouter = require('swagger-router');
 const path = require('path');
@@ -152,6 +154,40 @@ class Router {
         }
     }
 
+    _getCachedModule(modDef, globals) {
+        const modString = crypto.createHash('sha256')
+            .update(stringify(modDef, { cycles: true }))
+            .digest('hex');
+        const exportedGlobals = utils.exportGlobal(globals);
+        const globalHash = crypto.createHash('sha256')
+            .update(stringify(exportedGlobals, { cycles: true }))
+            .digest('hex');
+        let cachedModules = this._modules.get(modString);
+        if (!cachedModules) {
+            cachedModules = new Map();
+            this._modules.set(modString, cachedModules);
+        }
+        const cachedWithGlobals = cachedModules.get(globalHash);
+        return {
+            digest: modString,
+            module: cachedWithGlobals
+        };
+    }
+
+    _cacheModule(cacheInfo, mod) {
+        const cachedModules = this._modules.get(cacheInfo.digest);
+        const exportedGlobals = utils.exportGlobal(mod._parentGlobals);
+        const globalHash = crypto.createHash('sha256')
+            .update(stringify(exportedGlobals, { cycles: true }))
+            .digest('hex');
+        cachedModules.set(globalHash, mod);
+    }
+
+    _clearModuleCache() {
+        this._modules.forEach((value) => value.clear());
+        this._modules.clear();
+    }
+
     /**
      * Load and initialize a module
      * @param  {string}  modDef
@@ -159,11 +195,12 @@ class Router {
      * @return {Promise}
      */
     _loadModule(modDef, globals) {
+        const options = this._expandOptions(modDef, globals);
         // First, check if we have a copy of this module in the cache, so that we
         // can share it.
-        const cachedModule = this._modules.get(modDef);
-        if (cachedModule && cachedModule._parentGlobals === globals) {
-            return P.resolve(cachedModule);
+        const cached = this._getCachedModule(modDef, globals);
+        if (cached.module) {
+            return P.resolve(cached.module);
         }
 
         let loadPath;
@@ -209,8 +246,6 @@ class Router {
         }
         /* eslint-enable indent */
 
-        const options = this._expandOptions(modDef, globals);
-
         const constructModule = (spec) => {
             const mod = {
                 spec,
@@ -218,7 +253,7 @@ class Router {
                 // Needed to check cache validity.
                 _parentGlobals: globals
             };
-            this._modules.set(modDef, mod);
+            this._cacheModule(cached, mod);
             return mod;
         };
 
@@ -247,7 +282,7 @@ class Router {
                 mod.globals = mod.globals || { options };
                 // Needed to check cache validity.
                 mod._parentGlobals = globals;
-                this._modules.set(modDef, mod);
+                this._cacheModule(cached, mod);
                 return mod;
             });
         }
@@ -622,6 +657,7 @@ class Router {
             return this.handleResources(hyper);
         })
         .then(() => {
+            this._clearModuleCache();
             return this;
         });
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,7 +92,7 @@ utils.mergeDeep = (target, ...sources) => {
         return (item && typeof item === 'object' && !Array.isArray(item));
     };
 
-    if (!sources.length || !sources || !target || !isObject(target)) {
+    if (!sources || !sources.length || !target || !isObject(target)) {
         return target;
     }
 
@@ -113,6 +113,29 @@ utils.mergeDeep = (target, ...sources) => {
         }
     });
     return target;
+};
+
+utils.exportGlobal = (global) => {
+    if (!global || ['string', 'number', 'boolean'].includes(typeof global)) {
+        return global;
+    }
+    if (Array.isArray(global)) {
+        return global.map((x) => utils.exportGlobal(x));
+    }
+    if (global.constructor === Object) {
+        // because the logger appears at various positions in the globals, we need
+        // to filter it out as it depends on its position how it gets stringified
+        // TODO: figure out how to get rid of the logger altogether, as it really
+        // shouldn't be part of the globals object
+        const keys = Object.keys(global).filter((item) => item !== 'logger' &&
+            !!global[item] && typeof global[item] !== 'function');
+        const ret = {};
+        keys.forEach((x) => {
+            ret[x] = utils.exportGlobal(global[x]);
+        });
+        return ret;
+    }
+    return global;
 };
 
 module.exports = utils;


### PR DESCRIPTION
Module caching and sharing has always been completely broken. That
stemmed  from the fact that using the `===` operator on Objects results
in a truth-y evaluation iff the objects being tested have the same
reference, i.e. they are the same object. Objects were used both as keys
and as values during the caching process, which meant that no module was
ever shared effectively. Furthermore, it is important that the context
in which the module is being loaded matches the one used by the
previous-cached module. Here, again, the process suffered from equality
comparison problems.

In order to make module caching and sharing work, this commit switches
to using the SHA1 digest of the module definition as its caching key,
allowing us to retrieve the cached module based on the value of the
definition instead of its reference. To counter the problem of context
checking, we now cache an 'exportable' version of the context as well
in addition to the module definition.