### PR TITLE
Allow the service to skip issuing resource requests

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -551,6 +551,9 @@ class Router {
      * @return {Promise}
      */
     handleResources(hyper) {
+        if (this._options.conf && this._options.conf.skip_resources) {
+            return P.resolve();
+        }
         return this.tree.visitAsync((value, path) => {
             if (value && Array.isArray(value.resources) && value.resources.length > 0) {
                 return P.each(value.resources, (reqSpec) => {


### PR DESCRIPTION
A module may specify PUT requests to be made once the loading of the
spec is complete in order to fully set the system up. However, in the
case of RESTRouter that is not needed nor desirable, since (i) RESTBase
back-end already performs these; and (ii) issuing these requests over
network significantly prolongs the start-up sequence.