### PR TITLE
Fix local IP address detection 

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -1,0 +1,10 @@
+/**
+ * Regular expression to classify if a valid IPv4 or IPv6 address is local.
+ * Note: does not validate that the string is a valid IPv4 or IPv6 address.
+ * Note: assumes the local IP address uses the private class A address range.
+ */
+const LOCAL_IP = /^::1|(?:::ffff:)?(?:10|127)\./;
+
+module.exports = {
+    LOCAL_IP
+};

--- a/lib/regex.js
+++ b/lib/regex.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Regular expression to classify if a valid IPv4 or IPv6 address is local.
  * Note: does not validate that the string is a valid IPv4 or IPv6 address.

--- a/lib/regex.js
+++ b/lib/regex.js
@@ -3,7 +3,7 @@
  * Note: does not validate that the string is a valid IPv4 or IPv6 address.
  * Note: assumes the local IP address uses the private class A address range.
  */
-const LOCAL_IP = /^::1|(?:::ffff:)?(?:10|127)\./;
+const LOCAL_IP = /^::1$|^(?:::ffff:)?(?:10|127)\./;
 
 module.exports = {
     LOCAL_IP

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,6 +20,7 @@ const URI = require('swagger-router').URI;
 
 const exporting = require('./exports');
 const HyperSwitch = require('./hyperswitch');
+const Regex = require('./regex');
 const Router = require('./router');
 const utils = require('./utils');
 
@@ -284,7 +285,7 @@ function handleRequest(opts, req, resp) {
      * request are thus recorded in .internal or .internal_update prefixed
      * metric trees.
      */
-    if (/^::1|(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
+    if (Regex.LOCAL_IP.test(remoteAddr)) {
         if (req.headers['cache-control'] && /no-cache/i.test(req.headers['cache-control'])) {
             reqOpts.metrics = opts.child_metrics.internal_update;
             req.headers['x-request-class'] = 'internal_update';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswitch",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "REST API creation framework",
   "main": "index.js",
   "scripts": {

--- a/test/regex/regex.unit.js
+++ b/test/regex/regex.unit.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var assert = require('../utils/assert.js');
+var lib = require('../../lib/regex');
+
+describe('Regular expressions', () => {
+    describe('should recognize internal addresses', () => {
+        it('IPv4: loopback address to the local host', () => {
+            assert.deepEqual(lib.LOCAL_IP.test('127.0.0.1'), true);
+        });
+
+        it('IPv4: private address, class A', () => {
+            assert.deepEqual(lib.LOCAL_IP.test('10.0.0.1'), true);
+        });
+
+        it('IPv6: loopback address to the local host', () => {
+            assert.deepEqual(lib.LOCAL_IP.test('::1'), true);
+        });
+
+        it('IPv6: IPv4 mapped address', () => {
+            assert.deepEqual(lib.LOCAL_IP.test('::ffff:10.0.0.0'), true);
+        });
+    });
+
+    describe('should recognize external addresses', () => {
+        it('external IPv4 address', () => {
+            assert.deepEqual(lib.LOCAL_IP.test('55.55.55.55'), false);
+        });
+
+        // https://phabricator.wikimedia.org/T247770
+        it('external IPv4 address with a 10 inside', () => {
+            assert.deepEqual(lib.LOCAL_IP.test('55.55.10.55'), false);
+        });
+
+        // https://phabricator.wikimedia.org/T247770
+        it('external IPv4 address with a 127 inside', () => {
+            assert.deepEqual(lib.LOCAL_IP.test('55.127.55.55'), false);
+        });
+    });
+});


### PR DESCRIPTION
Fix regular expression classifying an IP address as local to the WMF environment.

This is why some requests in Logstash are marked as `internal_update` when they are external.

https://phabricator.wikimedia.org/T247770