### PR TITLE
[doc] switching from freenode to libera.chat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: false
 notifications:
   irc:
     channels:
-      - "irc.freenode.org#wikimedia-services"
+      - "irc.libera.chat#wikimedia-services"
     on_success: change
     on_failure: always
 


### PR DESCRIPTION
Updating references in documentation to point to libera.chat instead
of freenode.

See https://meta.wikimedia.org/wiki/IRC/Migrating_to_Libera_Chat

Bug: T283273